### PR TITLE
Use a reference when zeroing image numbers

### DIFF
--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -108,7 +108,7 @@ Header StreamReader::readHeaderVersion1() {
 
   // Currently the imageNumbers seem to be 1 indexed, we hope this will change.
   // for now, convert them to 0 indexed to make the rest of the code easier.
-  auto imageNumbers = header.imageNumbers;
+  auto& imageNumbers = header.imageNumbers;
   for(int i=0; i< header.imagesInBlock; i++) {
     imageNumbers[i]-= 1;
   }


### PR DESCRIPTION
Since a reference wasn't being used, a copy was being made,
and then the copy was zeroed. This resulted in the original
image numbers being unchanged, and it resulted in completely
white bright and dark fields.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>