### PR TITLE
Import pybind11 modules in the new __init__.py

### DIFF
--- a/python/stempy/__init__.py
+++ b/python/stempy/__init__.py
@@ -1,0 +1,1 @@
+import _image, _io

--- a/python/stempy/__init__.py
+++ b/python/stempy/__init__.py
@@ -1,1 +1,0 @@
-import _image, _io

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='stempy',
@@ -16,7 +16,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     keywords='',
-    packages=find_packages('python'),
+    packages=['stempy', 'stempy.io', 'stempy.image'],
     package_dir={'':'python'},
     install_requires=[
         'numpy',


### PR DESCRIPTION
Otherwise, `_io` and `_image` will fail to get imported
for local development.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>