### PR TITLE
Allow center of annular masks to be specified

### DIFF
--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -3,9 +3,11 @@ import numpy as np
 from collections import namedtuple
 
 def create_stem_image(reader, inner_radius,
-                      outer_radius, width=0, height=0):
+                      outer_radius, width=0, height=0,
+                      center_x=-1, center_y=-1):
     img =  _image.create_stem_image(reader.begin(), reader.end(),
-                                    inner_radius, outer_radius, width, height)
+                                    inner_radius, outer_radius, width, height,
+                                    center_x, center_y)
 
     image = namedtuple('STEMImage', ['bright', 'dark'])
     image.bright = np.array(img.bright, copy = False)

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -157,7 +157,8 @@ void _runCalculateSTEMValues(const Block& block, uint32_t numberOfPixels,
 
 template <typename InputIt>
 STEMImage createSTEMImage(InputIt first, InputIt last, int innerRadius,
-                          int outerRadius, int rows, int columns)
+                          int outerRadius, int rows, int columns, int centerX,
+                          int centerY)
 {
   if (first == last) {
     ostringstream msg;
@@ -185,8 +186,11 @@ STEMImage createSTEMImage(InputIt first, InputIt last, int innerRadius,
   auto detectorImageColumns = first->header.frameColumns;
   auto numberOfPixels = detectorImageRows * detectorImageRows;
 
-  auto brightFieldMask = createAnnularMask(detectorImageRows, detectorImageColumns, 0, outerRadius);
-  auto darkFieldMask = createAnnularMask(detectorImageRows, detectorImageColumns, innerRadius, outerRadius);
+  auto brightFieldMask = createAnnularMask(
+    detectorImageRows, detectorImageColumns, 0, outerRadius, centerX, centerY);
+  auto darkFieldMask =
+    createAnnularMask(detectorImageRows, detectorImageColumns, innerRadius,
+                      outerRadius, centerX, centerY);
 
 #ifdef VTKm
   // Only transfer the mask once.
@@ -273,11 +277,11 @@ Image<double> calculateAverage(InputIt first, InputIt last)
 template STEMImage createSTEMImage(StreamReader::iterator first,
                                    StreamReader::iterator last, int rows,
                                    int columns, int innerRadius,
-                                   int outerRadius);
+                                   int outerRadius, int centerX, int centerY);
 template STEMImage createSTEMImage(vector<Block>::iterator first,
                                    vector<Block>::iterator last, int rows,
                                    int columns, int innerRadius,
-                                   int outerRadius);
+                                   int outerRadius, int centerX, int centerY);
 
 template Image<double> calculateAverage(StreamReader::iterator first,
                                         StreamReader::iterator last);

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -38,7 +38,8 @@ namespace stempy {
 
   template <typename InputIt>
   STEMImage createSTEMImage(InputIt first, InputIt last, int innerRadius,
-                            int outerRadius, int rows = 0, int columns = 0);
+                            int outerRadius, int rows = 0, int columns = 0,
+                            int centerX = -1, int centerY = -1);
   STEMValues calculateSTEMValues(uint16_t data[], int offset,
                                  int numberOfPixels,
                                  uint16_t brightFieldMask[],

--- a/stempy/mask.cpp
+++ b/stempy/mask.cpp
@@ -7,11 +7,18 @@ using namespace std;
 
 namespace stempy {
 
-uint16_t* createAnnularMask(int rows, int columns, int innerRadius, int outerRadius) {
+uint16_t* createAnnularMask(int rows, int columns, int innerRadius,
+                            int outerRadius, int centerX, int centerY)
+{
   auto numberOfElements = rows*columns;
   auto mask = new uint16_t[numberOfElements]();
-  auto xCenter = round(rows/2.0);
-  auto yCenter = round(rows/2.0);
+
+  if (centerX < 0)
+    centerX = round(rows / 2.0);
+
+  if (centerY < 0)
+    centerY = round(rows / 2.0);
+
   innerRadius = static_cast<int>(pow(innerRadius, 2.0));
   outerRadius = static_cast<int>(pow(outerRadius, 2.0));
 
@@ -19,7 +26,7 @@ uint16_t* createAnnularMask(int rows, int columns, int innerRadius, int outerRad
     auto x = i % rows;
     auto y = i / rows;
 
-    auto d = pow((x-xCenter), 2.0) + pow((y-yCenter), 2.0);
+    auto d = pow((x - centerX), 2.0) + pow((y - centerY), 2.0);
     mask[i] = d >= innerRadius && d < outerRadius ? 0xFFFF : 0;
   }
 

--- a/stempy/mask.cpp
+++ b/stempy/mask.cpp
@@ -14,7 +14,7 @@ uint16_t* createAnnularMask(int rows, int columns, int innerRadius,
   auto mask = new uint16_t[numberOfElements]();
 
   if (centerX < 0)
-    centerX = round(rows / 2.0);
+    centerX = round(columns / 2.0);
 
   if (centerY < 0)
     centerY = round(rows / 2.0);

--- a/stempy/mask.h
+++ b/stempy/mask.h
@@ -8,8 +8,9 @@
 
 namespace stempy {
 
-  uint16_t* createAnnularMask(int rows, int columns, int innerRadius, int outerRadius);
-
+uint16_t* createAnnularMask(int rows, int columns, int innerRadius,
+                            int outerRadius, int centerX = -1,
+                            int centerY = -1);
 }
 
 #endif


### PR DESCRIPTION
If the values for the centers are less than 0, they
will be automatically calculated.

Fixes: #39

For our stem image sample, the default, 288, is this:

Bright
=====
![bright_original](https://user-images.githubusercontent.com/9558430/57795657-8bcc8b00-7714-11e9-8c52-c5047f75d1d3.png)

Dark
====
![dark_original](https://user-images.githubusercontent.com/9558430/57795658-8bcc8b00-7714-11e9-8461-bbe663cc01ec.png)

If we change it to 250, for example:

Bright
=====
![bright](https://user-images.githubusercontent.com/9558430/57795733-b3bbee80-7714-11e9-861c-eaaa73429296.png)


Dark
====
![dark](https://user-images.githubusercontent.com/9558430/57795719-ae5ea400-7714-11e9-850a-b4da170d6d04.png)
