### PR TITLE
Added ability to create many stem images in one go

### DIFF
--- a/examples/electron_stem_image.py
+++ b/examples/electron_stem_image.py
@@ -33,4 +33,4 @@ img = image.create_stem_image_sparse(frames, inner_radius, outer_radius,
                                      scan_width, scan_height, frame_width,
                                      frame_height)
 
-save_img(img.data, 'img.png', scan_width, scan_height)
+save_img(img, 'img.png', scan_width, scan_height)

--- a/examples/electron_stem_image.py
+++ b/examples/electron_stem_image.py
@@ -33,5 +33,4 @@ img = image.create_stem_image_sparse(frames, inner_radius, outer_radius,
                                      scan_width, scan_height, frame_width,
                                      frame_height)
 
-save_img(img.bright, 'bright.png', scan_width, scan_height)
-save_img(img.dark, 'dark.png', scan_width, scan_height)
+save_img(img.data, 'img.png', scan_width, scan_height)

--- a/examples/stem_image.ipynb
+++ b/examples/stem_image.ipynb
@@ -26,8 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inner_radii = [0, 40, 80]\n",
-    "outer_radii = [248, 288, 328]"
+    "inner_radii = [0, 40]\n",
+    "outer_radii = [288, 288]"
    ]
   },
   {
@@ -48,7 +48,7 @@
    "source": [
     "for img in imgs:\n",
     "    fig,ax=plt.subplots(figsize=(6,6))\n",
-    "    ax.matshow(img.data, cmap=plt.cm.gray)\n",
+    "    ax.matshow(img, cmap=plt.cm.gray)\n",
     "    plt.show()"
    ]
   }

--- a/examples/stem_image.ipynb
+++ b/examples/stem_image.ipynb
@@ -26,8 +26,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "inner_radii = [40, 50, 60]\n",
+    "outer_radii = [288, 298, 308]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "reader = io.reader(files)\n",
-    "img = image.create_stem_image(reader, 40, 288, width=160, height=160)"
+    "imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160, height=160)"
    ]
   },
   {
@@ -36,9 +46,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig,ax=plt.subplots(figsize=(6,6))\n",
-    "ax.matshow(img.bright, cmap=plt.cm.gray)\n",
-    "plt.show()"
+    "for img in imgs:\n",
+    "    fig,ax=plt.subplots(figsize=(6,6))\n",
+    "    ax.matshow(img.bright, cmap=plt.cm.gray)\n",
+    "    plt.show()"
    ]
   },
   {
@@ -47,9 +58,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig,ax=plt.subplots(figsize=(6,6))\n",
-    "ax.matshow(img.dark, cmap=plt.cm.gray)\n",
-    "plt.show()"
+    "for img in imgs:\n",
+    "    fig,ax=plt.subplots(figsize=(6,6))\n",
+    "    ax.matshow(img.dark, cmap=plt.cm.gray)\n",
+    "    plt.show()"
    ]
   }
  ],

--- a/examples/stem_image.ipynb
+++ b/examples/stem_image.ipynb
@@ -26,8 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inner_radii = [40, 50, 60]\n",
-    "outer_radii = [288, 298, 308]"
+    "inner_radii = [0, 40, 80]\n",
+    "outer_radii = [248, 288, 328]"
    ]
   },
   {
@@ -48,19 +48,7 @@
    "source": [
     "for img in imgs:\n",
     "    fig,ax=plt.subplots(figsize=(6,6))\n",
-    "    ax.matshow(img.bright, cmap=plt.cm.gray)\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for img in imgs:\n",
-    "    fig,ax=plt.subplots(figsize=(6,6))\n",
-    "    ax.matshow(img.dark, cmap=plt.cm.gray)\n",
+    "    ax.matshow(img.data, cmap=plt.cm.gray)\n",
     "    plt.show()"
    ]
   }

--- a/examples/stem_image.py
+++ b/examples/stem_image.py
@@ -21,8 +21,8 @@ files = []
 for f in glob.glob('/data/4dstem/smallScanningDiffraction/data*.dat'):
     files.append(f)
 
-inner_radii = [40, 50, 60]
-outer_radii = [288, 298, 308]
+inner_radii = [0, 40, 80]
+outer_radii = [248, 288, 328]
 
 reader = io.reader(files)
 imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160,
@@ -30,5 +30,4 @@ imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160,
 
 for i, img in enumerate(imgs):
     suffix = str(inner_radii[i]) + '_' + str(outer_radii[i]) + '.png'
-    save_img(img.bright, 'bright_' + suffix)
-    save_img(img.dark, 'dark_' + suffix)
+    save_img(img.data, 'img_' + suffix)

--- a/examples/stem_image.py
+++ b/examples/stem_image.py
@@ -21,8 +21,14 @@ files = []
 for f in glob.glob('/data/4dstem/smallScanningDiffraction/data*.dat'):
     files.append(f)
 
-reader = io.reader(files)
-img = image.create_stem_image(reader, 40, 288, width=160, height=160)
+inner_radii = [40, 50, 60]
+outer_radii = [288, 298, 308]
 
-save_img(img.bright, 'bright.png')
-save_img(img.dark, 'dark.png')
+reader = io.reader(files)
+imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160,
+                                height=160)
+
+for i, img in enumerate(imgs):
+  suffix = str(inner_radii[i]) + '_' + str(outer_radii[i]) + '.png'
+  save_img(img.bright, 'bright_' + suffix)
+  save_img(img.dark, 'dark_' + suffix)

--- a/examples/stem_image.py
+++ b/examples/stem_image.py
@@ -21,8 +21,8 @@ files = []
 for f in glob.glob('/data/4dstem/smallScanningDiffraction/data*.dat'):
     files.append(f)
 
-inner_radii = [0, 40, 80]
-outer_radii = [248, 288, 328]
+inner_radii = [0, 40]
+outer_radii = [288, 288]
 
 reader = io.reader(files)
 imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160,
@@ -30,4 +30,4 @@ imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160,
 
 for i, img in enumerate(imgs):
     suffix = str(inner_radii[i]) + '_' + str(outer_radii[i]) + '.png'
-    save_img(img.data, 'img_' + suffix)
+    save_img(img, 'img_' + suffix)

--- a/examples/stem_image.py
+++ b/examples/stem_image.py
@@ -29,6 +29,6 @@ imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160,
                                 height=160)
 
 for i, img in enumerate(imgs):
-  suffix = str(inner_radii[i]) + '_' + str(outer_radii[i]) + '.png'
-  save_img(img.bright, 'bright_' + suffix)
-  save_img(img.dark, 'dark_' + suffix)
+    suffix = str(inner_radii[i]) + '_' + str(outer_radii[i]) + '.png'
+    save_img(img.bright, 'bright_' + suffix)
+    save_img(img.dark, 'dark_' + suffix)

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -39,7 +39,7 @@ PYBIND11_MODULE(_image, m)
 
   // Add more template instantiations as we add more types of iterators
   m.def("create_stem_images", &createSTEMImages<StreamReader::iterator>);
-  m.def("create_stem_image_sparse", &createSTEMImageSparse);
+  m.def("create_stem_images_sparse", &createSTEMImagesSparse);
   m.def("calculate_average", &calculateAverage<StreamReader::iterator>);
   m.def("electron_count", &electronCount<StreamReader::iterator>);
   m.def("calculate_thresholds", &calculateThresholds);

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -43,7 +43,7 @@ PYBIND11_MODULE(_image, m)
     .def_readonly("dark", &STEMImage::dark);
 
   // Add more template instantiations as we add more types of iterators
-  m.def("create_stem_image", &createSTEMImage<StreamReader::iterator>);
+  m.def("create_stem_images", &createSTEMImages<StreamReader::iterator>);
   m.def("create_stem_image_sparse", &createSTEMImageSparse);
   m.def("calculate_average", &calculateAverage<StreamReader::iterator>);
   m.def("electron_count", &electronCount<StreamReader::iterator>);

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -37,11 +37,6 @@ PYBIND11_MODULE(_image, m)
             sizeof(double) });
     });
 
-
-  py::class_<STEMImage>(m, "_stem_image")
-    .def_readonly("bright", &STEMImage::bright)
-    .def_readonly("dark", &STEMImage::dark);
-
   // Add more template instantiations as we add more types of iterators
   m.def("create_stem_images", &createSTEMImages<StreamReader::iterator>);
   m.def("create_stem_image_sparse", &createSTEMImageSparse);

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -11,9 +11,8 @@ def create_stem_images(reader, inner_radii,
 
     images = []
     for img in imgs:
-        image = namedtuple('STEMImage', ['bright', 'dark'])
-        image.bright = np.array(img.bright, copy = False)
-        image.dark = np.array(img.dark, copy = False)
+        image = namedtuple('STEMImage', ['data'])
+        image.data = np.array(img, copy = False)
         images.append(image)
 
     return images
@@ -31,9 +30,8 @@ def create_stem_image_sparse(data, inner_radius, outer_radius,
                                            width, height, frame_width,
                                            frame_height, center_x, center_y)
 
-    image = namedtuple('STEMImage', ['bright', 'dark'])
-    image.bright = np.array(img.bright, copy = False)
-    image.dark = np.array(img.dark, copy = False)
+    image = namedtuple('STEMImage', ['data'])
+    image.data = np.array(img, copy = False)
 
     return image
 

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -1,6 +1,5 @@
 from stempy import _image
 import numpy as np
-from collections import namedtuple
 
 def create_stem_images(reader, inner_radii,
                        outer_radii, width=0, height=0,
@@ -11,11 +10,9 @@ def create_stem_images(reader, inner_radii,
 
     images = []
     for img in imgs:
-        image = namedtuple('STEMImage', ['data'])
-        image.data = np.array(img, copy = False)
-        images.append(image)
+        images.append(np.array(img, copy=False))
 
-    return images
+    return np.array(images, copy=False)
 
 # This one exists for backward compatibility
 def create_stem_image(reader, inner_radius, outer_radius, width=0, height=0,
@@ -23,17 +20,14 @@ def create_stem_image(reader, inner_radius, outer_radius, width=0, height=0,
     return create_stem_images(reader, (inner_radius,), (outer_radius,),
                               width, height, center_x, center_y)[0]
 
-def create_stem_image_sparse(data, inner_radius, outer_radius,
-                             width, height, frame_width, frame_height,
-                             center_x=-1, center_y=-1):
+def create_stems_image_sparse(data, inner_radius, outer_radius,
+                              width, height, frame_width, frame_height,
+                              center_x=-1, center_y=-1):
     img =  _image.create_stem_image_sparse(data, inner_radius, outer_radius,
                                            width, height, frame_width,
                                            frame_height, center_x, center_y)
 
-    image = namedtuple('STEMImage', ['data'])
-    image.data = np.array(img, copy = False)
-
-    return image
+    return np.array(img, copy=False)
 
 class ImageArray(np.ndarray):
     def __new__(cls, array, dtype=None, order=None):

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -8,10 +8,7 @@ def create_stem_images(reader, inner_radii,
                                      inner_radii, outer_radii, width, height,
                                      center_x, center_y)
 
-    images = []
-    for img in imgs:
-        images.append(np.array(img, copy=False))
-
+    images = [np.array(img, copy=False) for img in imgs]
     return np.array(images, copy=False)
 
 # This one exists for backward compatibility
@@ -27,10 +24,7 @@ def create_stem_images_sparse(data, inner_radius, outer_radius,
                                             width, height, frame_width,
                                             frame_height, center_x, center_y)
 
-    images = []
-    for img in imgs:
-        images.append(np.array(img, copy=False))
-
+    images = [np.array(img, copy=False) for img in imgs]
     return np.array(images, copy=False)
 
 def create_stem_image_sparse(data, inner_radius, outer_radius,

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -2,18 +2,27 @@ from stempy import _image
 import numpy as np
 from collections import namedtuple
 
-def create_stem_image(reader, inner_radius,
-                      outer_radius, width=0, height=0,
+def create_stem_images(reader, inner_radii,
+                       outer_radii, width=0, height=0,
+                       center_x=-1, center_y=-1):
+    imgs = _image.create_stem_images(reader.begin(), reader.end(),
+                                     inner_radii, outer_radii, width, height,
+                                     center_x, center_y)
+
+    images = []
+    for img in imgs:
+        image = namedtuple('STEMImage', ['bright', 'dark'])
+        image.bright = np.array(img.bright, copy = False)
+        image.dark = np.array(img.dark, copy = False)
+        images.append(image)
+
+    return images
+
+# This one exists for backward compatibility
+def create_stem_image(reader, inner_radius, outer_radius, width=0, height=0,
                       center_x=-1, center_y=-1):
-    img =  _image.create_stem_image(reader.begin(), reader.end(),
-                                    inner_radius, outer_radius, width, height,
-                                    center_x, center_y)
-
-    image = namedtuple('STEMImage', ['bright', 'dark'])
-    image.bright = np.array(img.bright, copy = False)
-    image.dark = np.array(img.dark, copy = False)
-
-    return image
+    return create_stem_images(reader, (inner_radius,), (outer_radius,),
+                              width, height, center_x, center_y)[0]
 
 def create_stem_image_sparse(data, inner_radius, outer_radius,
                              width, height, frame_width, frame_height,

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -20,14 +20,25 @@ def create_stem_image(reader, inner_radius, outer_radius, width=0, height=0,
     return create_stem_images(reader, (inner_radius,), (outer_radius,),
                               width, height, center_x, center_y)[0]
 
-def create_stems_image_sparse(data, inner_radius, outer_radius,
+def create_stem_images_sparse(data, inner_radius, outer_radius,
                               width, height, frame_width, frame_height,
                               center_x=-1, center_y=-1):
-    img =  _image.create_stem_image_sparse(data, inner_radius, outer_radius,
-                                           width, height, frame_width,
-                                           frame_height, center_x, center_y)
+    imgs = _image.create_stem_images_sparse(data, inner_radius, outer_radius,
+                                            width, height, frame_width,
+                                            frame_height, center_x, center_y)
 
-    return np.array(img, copy=False)
+    images = []
+    for img in imgs:
+        images.append(np.array(img, copy=False))
+
+    return np.array(images, copy=False)
+
+def create_stem_image_sparse(data, inner_radius, outer_radius,
+                             width, height, frame_width, frame_height,
+                             center_x=-1, center_y=-1):
+    return create_stem_images_sparse(data, [inner_radius], [outer_radius],
+                                     width, height, frame_width, frame_height,
+                                     center_x, center_y)[0]
 
 class ImageArray(np.ndarray):
     def __new__(cls, array, dtype=None, order=None):

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -80,5 +80,4 @@ def save_electron_counts(path, events, scan_nx, scan_ny, detector_nx=None, detec
 def save_stem_image(outputFile, image):
     with h5py.File(outputFile, 'a') as f:
         stem_group = f.require_group('stem')
-        stem_group.create_dataset('bright', data=image.bright)
-        stem_group.create_dataset('dark', data=image.dark)
+        stem_group.create_dataset('data', data=image.data)

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -93,10 +93,8 @@ STEMValues calculateSTEMValuesParallel(
 
   using ResultType = uint64_t;
   const ResultType initialVal(0);
-  ResultType result =
+  stemValues.data =
     vtkm::cont::Algorithm::Reduce(vector, initialVal, MaskAndAdd{});
-
-  stemValues.data = result;
 
   return stemValues;
 }

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -34,10 +34,11 @@ namespace stempy {
                                           int scanWidth = 0, int scanHeight = 0,
                                           int centerX = -1, int centerY = -1);
 
-  STEMImage createSTEMImageSparse(
-    const std::vector<std::vector<uint32_t>>& sparseData, int innerRadius,
-    int outerRadius, int rows, int columns, int frameWidth, int frameHeight,
-    int centerX = -1, int centerY = -1);
+  std::vector<STEMImage> createSTEMImagesSparse(
+    const std::vector<std::vector<uint32_t>>& sparseData,
+    std::vector<int> innerRadii, std::vector<int> outerRadii, int rows,
+    int columns, int frameWidth, int frameHeight, int centerX = -1,
+    int centerY = -1);
 
   STEMValues calculateSTEMValues(const uint16_t data[], int offset,
                                  int numberOfPixels, uint16_t mask[],

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -21,20 +21,11 @@ namespace stempy {
   };
 
   struct STEMValues {
-    uint64_t bright = 0;
-    uint64_t dark = 0;
+    uint64_t data = 0;
     uint32_t imageNumber = -1;
   };
 
-  struct STEMImage {
-    Image<uint64_t> bright;
-    Image<uint64_t> dark;
-
-    STEMImage() = default;
-    STEMImage(uint32_t width, uint32_t height);
-    STEMImage(STEMImage&& i) noexcept = default;
-    STEMImage& operator=(STEMImage&& i) noexcept = default;
-  };
+  using STEMImage = Image<uint64_t>;
 
   template <typename InputIt>
   std::vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
@@ -49,9 +40,7 @@ namespace stempy {
     int centerX = -1, int centerY = -1);
 
   STEMValues calculateSTEMValues(const uint16_t data[], int offset,
-                                 int numberOfPixels,
-                                 uint16_t brightFieldMask[],
-                                 uint16_t darkFieldMask[],
+                                 int numberOfPixels, uint16_t mask[],
                                  uint32_t imageNumber = -1);
 
   template <typename InputIt>

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -37,9 +37,11 @@ namespace stempy {
   };
 
   template <typename InputIt>
-  STEMImage createSTEMImage(InputIt first, InputIt last, int innerRadius,
-                            int outerRadius, int scanWidth = 0, int scanHeight = 0,
-                            int centerX = -1, int centerY = -1);
+  std::vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
+                                          std::vector<int> innerRadii,
+                                          std::vector<int> outerRadii,
+                                          int scanWidth = 0, int scanHeight = 0,
+                                          int centerX = -1, int centerY = -1);
 
   STEMImage createSTEMImageSparse(
     const std::vector<std::vector<uint32_t>>& sparseData, int innerRadius,


### PR DESCRIPTION
Multiple stem images can now be created in one go, which can
save a lot of time compared to doing them all individually.

A couple of python examples were modified to illustrate the new API.
But the old python API still works for backward compatibility.