### PR TITLE
Modify save_stem_images() to allow compatibility

### DIFF
--- a/examples/create_hdf5.py
+++ b/examples/create_hdf5.py
@@ -58,13 +58,17 @@ def make_stem_hdf5(files, dark_sample, width, height, inner_radius,
     detector_nx = block.header.frame_width
     detector_ny = block.header.frame_height
 
+    inner_radii = [0, inner_radius]
+    outer_radii = [outer_radius, outer_radius]
+    names = ['bright', 'dark']
+
     reader.reset()
-    img = image.create_stem_image(reader, inner_radius, outer_radius,
-                                  width=width, height=height)
+    imgs = image.create_stem_images(reader, inner_radii, outer_radii,
+                                    width=width, height=height)
 
     io.save_electron_counts(output, frame_events, width, height, detector_nx,
                             detector_ny)
-    io.save_stem_image(output, img)
+    io.save_stem_images(output, imgs, names)
 
     if save_raw:
         reader.reset()

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -77,7 +77,8 @@ def save_electron_counts(path, events, scan_nx, scan_ny, detector_nx=None, detec
 
         frames[...] = events
 
-def save_stem_image(outputFile, image):
+def save_stem_images(outputFile, images, names):
     with h5py.File(outputFile, 'a') as f:
         stem_group = f.require_group('stem')
-        stem_group.create_dataset('data', data=image.data)
+        for image, name in zip(images, names):
+            stem_group.create_dataset(name, data=image)


### PR DESCRIPTION
Modify save_stem_images() so that the images may be saved
as `bright` and `dark` just as they were before. Now, a
list of images is passed along with a list of names.