### PR TITLE
Add decorator to declare the arguments of a pipeline

### DIFF
--- a/python/stempy/pipeline/__init__.py
+++ b/python/stempy/pipeline/__init__.py
@@ -1,5 +1,5 @@
 import abc
-
+from functools import wraps
 
 class Pipeline(abc.ABC):
 
@@ -13,7 +13,26 @@ def pipeline(name=None, description=None):
     def _decorator(func):
         func.NAME = name
         func.DESCRIPTION = description
-
+        func.PARAMETERS = {}
         return func
+
+    return _decorator
+
+def parameter(name, type = 'string', label = None, description = None, default=None):
+
+    def _decorator(func):
+        func.PARAMETERS[name] = {
+            'type': type,
+            'label': label,
+            'description': description,
+            'default': default
+        }
+
+        @wraps(func)
+        def _wrapper(*args, **kwargs):
+            if name not in kwargs:
+                kwargs[name] = default
+            return func(*args, **kwargs)
+        return _wrapper
 
     return _decorator

--- a/python/stempy/pipeline/__init__.py
+++ b/python/stempy/pipeline/__init__.py
@@ -8,12 +8,16 @@ class Pipeline(abc.ABC):
         Execute pipeline
         """
 
+def _ensure_parameters(f):
+    if not hasattr(f, 'PARAMETERS'):
+        setattr(f, 'PARAMETERS', {})
+
 def pipeline(name=None, description=None):
 
     def _decorator(func):
         func.NAME = name
         func.DESCRIPTION = description
-        func.PARAMETERS = {}
+        _ensure_parameters(func)
         return func
 
     return _decorator
@@ -21,6 +25,7 @@ def pipeline(name=None, description=None):
 def parameter(name, type = 'string', label = None, description = None, default=None):
 
     def _decorator(func):
+        _ensure_parameters(func)
         func.PARAMETERS[name] = {
             'type': type,
             'label': label,


### PR DESCRIPTION
This is a possible way to declare the pipeline parameters in a way that can be sent over to the client to automatically generate the input forms.

Usage:
```python
from stempy.pipeline import pipeline, parameter

@pipeline('Annular Mask', 'Creates STEM images using annular masks')
@parameter('centerX', type='number', label='Center X', default=-1)
@parameter('centerY', type='number', label='Center Y', default=-1)
@parameter('innerRadius', type='number', label='Inner Radius', default=0)
@parameter('outerRadius', type='number', label='Outer Radius', default=0)
def execute(path=None, **params):
    centerX = params.get('centerX')
    centerY = params.get('centerY')
    innerRadius = params.get('innerRadius')
    outerRadius = params.get('outerRadius')
    # pipeline logic below
```

I'm open to discussion