### PR TITLE
Return dimensions from electronCount() function

### DIFF
--- a/examples/benchmark_electron_counting.py
+++ b/examples/benchmark_electron_counting.py
@@ -31,8 +31,8 @@ def run_benchmarks(files, dark_sample, num_runs):
         dark = image.calculate_average(reader)
 
         reader = io.reader(files, version=io.FileVersion.VERSION2)
-        frame_events = image.electron_count(reader, dark, scan_width=40,
-                                            scan_height=40)
+        data = image.electron_count(reader, dark, scan_width=40,
+                                    scan_height=40)
 
         end = time.time()
         times.append(end - start)

--- a/examples/create_hdf5.py
+++ b/examples/create_hdf5.py
@@ -49,14 +49,12 @@ def make_stem_hdf5(files, dark_sample, width, height, inner_radius,
     dark = image.calculate_average(reader)
 
     reader = io.reader(files, version=reader_version)
-    frame_events = image.electron_count(reader, dark, scan_width=width,
-                                        scan_height=height)
+    data = image.electron_count(reader, dark, scan_width=width,
+                                scan_height=height)
 
-    # Read one block in to get the detector frames
-    reader.reset()
-    block = reader.read()
-    detector_nx = block.header.frame_width
-    detector_ny = block.header.frame_height
+    frame_events = data.data
+    detector_nx = data.frame_height
+    detector_ny = data.frame_width
 
     inner_radii = [0, inner_radius]
     outer_radii = [outer_radius, outer_radius]

--- a/examples/electron.ipynb
+++ b/examples/electron.ipynb
@@ -28,7 +28,8 @@
    "outputs": [],
    "source": [
     "reader = io.reader('/data/scan_0000000236/stem4d_0000000236_0000000009.dat', version=io.FileVersion.VERSION2)\n",
-    "frame_events = image.electron_count(reader, dark, scan_width=40, scan_height=40)"
+    "electron_counted_data = image.electron_count(reader, dark, scan_width=40, scan_height=40)\n",
+    "frame_events = electron_counted_data.data"
    ]
   },
   {
@@ -37,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = np.zeros((576, 576))"
+    "img = np.zeros((576, 576))"
    ]
   },
   {
@@ -51,7 +52,7 @@
     "    for pos in frame:\n",
     "        row = pos // 576\n",
     "        column = pos % 576\n",
-    "        image[row][column] += 1\n"
+    "        img[row][column] += 1"
    ]
   },
   {
@@ -61,7 +62,29 @@
    "outputs": [],
    "source": [
     "fig,ax=plt.subplots(figsize=(12,12))\n",
-    "ax.matshow(image)\n",
+    "ax.matshow(img)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inner_radius = 40\n",
+    "outer_radius = 288\n",
+    "stem_img = image.create_stem_image_sparse(electron_counted_data, inner_radius, outer_radius)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,ax=plt.subplots(figsize=(12,12))\n",
+    "ax.matshow(stem_img)\n",
     "plt.show()"
    ]
   }

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -9,6 +9,7 @@
 
 namespace py = pybind11;
 
+using std::vector;
 using namespace stempy;
 
 PYBIND11_MODULE(_image, m)
@@ -50,11 +51,27 @@ PYBIND11_MODULE(_image, m)
             sizeof(uint64_t) });
     });
 
+  py::class_<ElectronCountedData>(m, "_electron_counted_data",
+                                  py::buffer_protocol())
+    .def_readonly("data", &ElectronCountedData::data)
+    .def_readonly("scan_width", &ElectronCountedData::scanWidth)
+    .def_readonly("scan_height", &ElectronCountedData::scanHeight)
+    .def_readonly("frame_width", &ElectronCountedData::frameWidth)
+    .def_readonly("frame_height", &ElectronCountedData::frameHeight);
 
   // Add more template instantiations as we add more types of iterators
   m.def("create_stem_images", &createSTEMImages<StreamReader::iterator>,
         py::call_guard<py::gil_scoped_release>());
-  m.def("create_stem_images_sparse", &createSTEMImagesSparse,
+  m.def(
+    "create_stem_images_sparse",
+    (vector<STEMImage>(*)(const vector<vector<uint32_t>>&, const vector<int>&,
+                          const vector<int>&, int, int, int, int, int, int)) &
+      createSTEMImagesSparse,
+    py::call_guard<py::gil_scoped_release>());
+  m.def("create_stem_images_sparse",
+        (vector<STEMImage>(*)(const ElectronCountedData&, const vector<int>&,
+                              const vector<int>&, int, int)) &
+          createSTEMImagesSparse,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_average", &calculateAverage<StreamReader::iterator>,
         py::call_guard<py::gil_scoped_release>());

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -5,13 +5,23 @@
 
 namespace stempy {
 
+struct ElectronCountedData
+{
+  std::vector<std::vector<uint32_t>> data;
+
+  // These types match those of the Header class
+  uint16_t scanWidth = 0;
+  uint16_t scanHeight = 0;
+  uint32_t frameWidth = 0;
+  uint32_t frameHeight = 0;
+};
+
 template <typename InputIt>
-std::vector<std::vector<uint32_t>> electronCount(InputIt first, InputIt last,
-                                                 Image<double>& darkreference,
-                                                 double backgroundThreshold,
-                                                 double xRayThreshold,
-                                                 int scanWidth = 0,
-                                                 int scanHeight = 0);
+ElectronCountedData electronCount(InputIt first, InputIt last,
+                                  Image<double>& darkreference,
+                                  double backgroundThreshold,
+                                  double xRayThreshold, int scanWidth = 0,
+                                  int scanHeight = 0);
 }
 
 #endif /* STEMPY_ELECTRON_H_ */

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -1,6 +1,7 @@
 #include "image.h"
 
 #include "config.h"
+#include "electron.h"
 #include "mask.h"
 
 #include <ThreadPool.h>
@@ -163,8 +164,8 @@ void _runCalculateSTEMValues(const uint16_t data[],
 
 template <typename InputIt>
 vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
-                                   vector<int> innerRadii,
-                                   vector<int> outerRadii, int width,
+                                   const vector<int>& innerRadii,
+                                   const vector<int>& outerRadii, int width,
                                    int height, int centerX, int centerY)
 {
   if (first == last) {
@@ -351,8 +352,8 @@ vector<uint16_t> expandSparsifiedData(const vector<vector<uint32_t>>& data,
 }
 
 vector<STEMImage> createSTEMImagesSparse(
-  const vector<vector<uint32_t>>& sparseData, vector<int> innerRadii,
-  vector<int> outerRadii, int width, int height, int frameWidth,
+  const vector<vector<uint32_t>>& sparseData, const vector<int>& innerRadii,
+  const vector<int>& outerRadii, int width, int height, int frameWidth,
   int frameHeight, int centerX, int centerY)
 {
   if (innerRadii.empty() || outerRadii.empty()) {
@@ -411,6 +412,16 @@ vector<STEMImage> createSTEMImagesSparse(
     delete[] p;
 
   return images;
+}
+
+vector<STEMImage> createSTEMImagesSparse(const ElectronCountedData& data,
+                                         const vector<int>& innerRadii,
+                                         const vector<int>& outerRadii,
+                                         int centerX, int centerY)
+{
+  return createSTEMImagesSparse(
+    data.data, innerRadii, outerRadii, data.scanWidth, data.scanHeight,
+    data.frameWidth, data.frameHeight, centerX, centerY);
 }
 
 template <typename InputIt>
@@ -653,15 +664,15 @@ RadialSum<uint64_t> radialSum(InputIt first, InputIt last, int scanWidth, int sc
 // Instantiate the ones that can be used
 template vector<STEMImage> createSTEMImages(StreamReader::iterator first,
                                             StreamReader::iterator last,
-                                            vector<int> innerRadii,
-                                            vector<int> outerRadii, int width,
-                                            int height, int centerX,
+                                            const vector<int>& innerRadii,
+                                            const vector<int>& outerRadii,
+                                            int width, int height, int centerX,
                                             int centerY);
 template vector<STEMImage> createSTEMImages(vector<Block>::iterator first,
                                             vector<Block>::iterator last,
-                                            vector<int> innerRadii,
-                                            vector<int> outerRadii, int width,
-                                            int height, int centerX,
+                                            const vector<int>& innerRadii,
+                                            const vector<int>& outerRadii,
+                                            int width, int height, int centerX,
                                             int centerY);
 
 template Image<double> calculateAverage(StreamReader::iterator first,

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -42,16 +42,21 @@ namespace stempy {
 
   template <typename InputIt>
   std::vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
-                                          std::vector<int> innerRadii,
-                                          std::vector<int> outerRadii,
+                                          const std::vector<int>& innerRadii,
+                                          const std::vector<int>& outerRadii,
                                           int scanWidth = 0, int scanHeight = 0,
                                           int centerX = -1, int centerY = -1);
 
   std::vector<STEMImage> createSTEMImagesSparse(
     const std::vector<std::vector<uint32_t>>& sparseData,
-    std::vector<int> innerRadii, std::vector<int> outerRadii, int rows,
-    int columns, int frameWidth, int frameHeight, int centerX = -1,
+    const std::vector<int>& innerRadii, const std::vector<int>& outerRadii,
+    int rows, int columns, int frameWidth, int frameHeight, int centerX = -1,
     int centerY = -1);
+
+  struct ElectronCountedData;
+  std::vector<STEMImage> createSTEMImagesSparse(
+    const ElectronCountedData& sparseData, const std::vector<int>& innerRadii,
+    const std::vector<int>& outerRadii, int centerX = -1, int centerY = -1);
 
   STEMValues calculateSTEMValues(const uint16_t data[], uint64_t offset,
                                  uint32_t numberOfPixels, uint16_t mask[],


### PR DESCRIPTION
A new struct, ElectronCountedData, was added that contains the previous
output of electronCount(), plus the scan and frame dimensions. This is
done so that the scan and frame dimensions can be obtained again later
in the code.

A new overload of createSTEMImagesSparse() was also added that takes in
an ElectronCountedData argument. This function can be called from the
python code as well.

An example of using the ElectronCountedData for creating a sparse stem
image can be seen now in `electron.ipynb`.

This fixes the third point of #76.