### PR TITLE
Allow electron threshold parameters to be doubles

### DIFF
--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -52,8 +52,8 @@ private:
 std::pair<double, double> calculateThresholds(std::vector<Block>& blocks,
                                               Image<double>& darkReference,
                                               int numberOfSamples,
-                                              int backgroundThresholdNSigma,
-                                              int xRayThresholdNSigma)
+                                              double backgroundThresholdNSigma,
+                                              double xRayThresholdNSigma)
 {
   auto frameWidth = blocks[0].header.frameWidth;
   auto frameHeight = blocks[0].header.frameHeight;

--- a/stempy/electronthresholds.h
+++ b/stempy/electronthresholds.h
@@ -8,8 +8,8 @@ namespace stempy {
 std::pair<double, double> calculateThresholds(std::vector<Block>& blocks,
                                               Image<double>& darkreference,
                                               int numberOfSamples = 20,
-                                              int backgroundThresholdNSigma = 4,
-                                              int xRayThresholdNSigma = 10);
+                                              double backgroundThresholdNSigma = 4,
+                                              double xRayThresholdNSigma = 10);
 }
 
 #endif /* STEMPY_ELECTRONTHRESHOLDS_H_ */


### PR DESCRIPTION
Allow the backgroundThresholdNSigma and xRayThresholdNSigma arguments
to be doubles instead of ints.

Fixes the first point in #76.