### PR TITLE
Add verbose option to electron threshold function

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -51,6 +51,24 @@ PYBIND11_MODULE(_image, m)
             sizeof(uint64_t) });
     });
 
+  py::class_<CalculateThresholdsResults>(m, "_calculate_thresholds_results",
+                                         py::buffer_protocol())
+    .def_readonly("background_threshold",
+                  &CalculateThresholdsResults::backgroundThreshold)
+    .def_readonly("xray_threshold", &CalculateThresholdsResults::xRayThreshold)
+    .def_readonly("number_of_samples",
+                  &CalculateThresholdsResults::numberOfSamples)
+    .def_readonly("min_sample", &CalculateThresholdsResults::minSample)
+    .def_readonly("max_sample", &CalculateThresholdsResults::maxSample)
+    .def_readonly("mean", &CalculateThresholdsResults::mean)
+    .def_readonly("variance", &CalculateThresholdsResults::variance)
+    .def_readonly("std_dev", &CalculateThresholdsResults::stdDev)
+    .def_readonly("number_of_bins", &CalculateThresholdsResults::numberOfBins)
+    .def_readonly("xray_threshold_n_sigma",
+                  &CalculateThresholdsResults::xRayThresholdNSigma)
+    .def_readonly("background_threshold_n_sigma",
+                  &CalculateThresholdsResults::backgroundThresholdNSigma);
+
   py::class_<ElectronCountedData>(m, "_electron_counted_data",
                                   py::buffer_protocol())
     .def_readonly("data", &ElectronCountedData::data)

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -93,9 +93,27 @@ def electron_count(reader, darkreference, number_of_samples=40,
     for i in range(threshold_num_blocks):
         blocks.append(next(reader))
 
-    background_threshold, xray_threshold = _image.calculate_thresholds(
+    res = _image.calculate_thresholds(
         [b._block for b in blocks], darkreference._image, number_of_samples,
-        background_threshold_n_sigma, xray_threshold_n_sigma, verbose)
+        background_threshold_n_sigma, xray_threshold_n_sigma)
+
+    background_threshold = res.background_threshold
+    xray_threshold = res.xray_threshold
+
+    if verbose:
+        print('****Statistics for calculating electron thresholds****')
+        print('number of samples:', res.number_of_samples)
+        print('min sample:', res.min_sample)
+        print('max sample:', res.max_sample)
+        print('mean:', res.mean)
+        print('variance:', res.variance)
+        print('std dev:', res.std_dev)
+        print('number of bins:', res.number_of_bins)
+        print('x-ray threshold n sigma:', res.xray_threshold_n_sigma)
+        print('background threshold n sigma:',
+              res.background_threshold_n_sigma)
+        print('background threshold:', background_threshold)
+        print('xray threshold:', xray_threshold)
 
     # Reset the reader
     reader.reset()

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -86,7 +86,8 @@ def calculate_average(reader):
 
 def electron_count(reader, darkreference, number_of_samples=40,
                    background_threshold_n_sigma=4, xray_threshold_n_sigma=10,
-                   threshold_num_blocks=1, scan_width=0, scan_height=0):
+                   threshold_num_blocks=1, scan_width=0, scan_height=0,
+                   verbose=False):
 
     blocks = []
     for i in range(threshold_num_blocks):
@@ -94,7 +95,7 @@ def electron_count(reader, darkreference, number_of_samples=40,
 
     background_threshold, xray_threshold = _image.calculate_thresholds(
         [b._block for b in blocks], darkreference._image, number_of_samples,
-        background_threshold_n_sigma, xray_threshold_n_sigma)
+        background_threshold_n_sigma, xray_threshold_n_sigma, verbose)
 
     # Reset the reader
     reader.reset()

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -2,14 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <random>
 
 #include <lsq/lsqcpp.h>
-
-using std::cerr;
-using std::cout;
-using std::endl;
 
 namespace stempy {
 
@@ -54,9 +49,11 @@ private:
   const std::vector<uint64_t>& histogram;
 };
 
-std::pair<double, double> calculateThresholds(
-  std::vector<Block>& blocks, Image<double>& darkReference, int numberOfSamples,
-  double backgroundThresholdNSigma, double xRayThresholdNSigma, bool verbose)
+CalculateThresholdsResults calculateThresholds(std::vector<Block>& blocks,
+                                               Image<double>& darkReference,
+                                               int numberOfSamples,
+                                               double backgroundThresholdNSigma,
+                                               double xRayThresholdNSigma)
 {
   auto frameWidth = blocks[0].header.frameWidth;
   auto frameHeight = blocks[0].header.frameHeight;
@@ -146,22 +143,20 @@ std::pair<double, double> calculateThresholds(
   auto backgroundThreshold =
     result.state[1] + result.state[2] * backgroundThresholdNSigma;
 
-  if (verbose) {
-    cout << "****Statistics for calculating electron thresholds****" << endl;
-    cout << "numberOfSamples: " << numberOfSamples << endl;
-    cout << "min: " << minSample << endl;
-    cout << "max: " << maxSample << endl;
-    cout << "mean: " << mean << endl;
-    cout << "variance: " << variance << endl;
-    cout << "stdDev: " << stdDev << endl;
-    cout << "numberOfBins: " << numberOfBins << endl;
-    cout << "xRayThresholdNSigma: " << xRayThresholdNSigma << endl;
-    cout << "backgroundThresholdNSigma: " << backgroundThresholdNSigma << endl;
-    cout << "xrayThreshold: " << xrayThreshold << endl;
-    cout << "backgroundThreshold: " << backgroundThreshold << endl;
-  }
+  CalculateThresholdsResults ret;
+  ret.numberOfSamples = numberOfSamples;
+  ret.minSample = minSample;
+  ret.maxSample = maxSample;
+  ret.mean = mean;
+  ret.variance = variance;
+  ret.stdDev = stdDev;
+  ret.numberOfBins = numberOfBins;
+  ret.xRayThresholdNSigma = xRayThresholdNSigma;
+  ret.backgroundThresholdNSigma = backgroundThresholdNSigma;
+  ret.xRayThreshold = xrayThreshold;
+  ret.backgroundThreshold = backgroundThreshold;
 
-  return std::make_pair(backgroundThreshold, xrayThreshold);
+  return ret;
 }
 
 }

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -2,9 +2,14 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <random>
 
 #include <lsq/lsqcpp.h>
+
+using std::cerr;
+using std::cout;
+using std::endl;
 
 namespace stempy {
 
@@ -49,11 +54,9 @@ private:
   const std::vector<uint64_t>& histogram;
 };
 
-std::pair<double, double> calculateThresholds(std::vector<Block>& blocks,
-                                              Image<double>& darkReference,
-                                              int numberOfSamples,
-                                              double backgroundThresholdNSigma,
-                                              double xRayThresholdNSigma)
+std::pair<double, double> calculateThresholds(
+  std::vector<Block>& blocks, Image<double>& darkReference, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma, bool verbose)
 {
   auto frameWidth = blocks[0].header.frameWidth;
   auto frameHeight = blocks[0].header.frameHeight;
@@ -142,6 +145,21 @@ std::pair<double, double> calculateThresholds(std::vector<Block>& blocks,
   }
   auto backgroundThreshold =
     result.state[1] + result.state[2] * backgroundThresholdNSigma;
+
+  if (verbose) {
+    cout << "****Statistics for calculating electron thresholds****" << endl;
+    cout << "numberOfSamples: " << numberOfSamples << endl;
+    cout << "min: " << minSample << endl;
+    cout << "max: " << maxSample << endl;
+    cout << "mean: " << mean << endl;
+    cout << "variance: " << variance << endl;
+    cout << "stdDev: " << stdDev << endl;
+    cout << "numberOfBins: " << numberOfBins << endl;
+    cout << "xRayThresholdNSigma: " << xRayThresholdNSigma << endl;
+    cout << "backgroundThresholdNSigma: " << backgroundThresholdNSigma << endl;
+    cout << "xrayThreshold: " << xrayThreshold << endl;
+    cout << "backgroundThreshold: " << backgroundThreshold << endl;
+  }
 
   return std::make_pair(backgroundThreshold, xrayThreshold);
 }

--- a/stempy/electronthresholds.h
+++ b/stempy/electronthresholds.h
@@ -5,10 +5,25 @@
 
 namespace stempy {
 
-std::pair<double, double> calculateThresholds(
+struct CalculateThresholdsResults
+{
+  double backgroundThreshold = 0.0;
+  double xRayThreshold = 0.0;
+  int numberOfSamples = 0;
+  int16_t minSample = 0;
+  int16_t maxSample = 0;
+  double mean = 0.0;
+  double variance = 0.0;
+  double stdDev = 0.0;
+  int numberOfBins = 0;
+  double xRayThresholdNSigma = 0.0;
+  double backgroundThresholdNSigma = 0.0;
+};
+
+CalculateThresholdsResults calculateThresholds(
   std::vector<Block>& blocks, Image<double>& darkreference,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10, bool verbose = false);
+  double xRayThresholdNSigma = 10);
 }
 
 #endif /* STEMPY_ELECTRONTHRESHOLDS_H_ */

--- a/stempy/electronthresholds.h
+++ b/stempy/electronthresholds.h
@@ -5,11 +5,10 @@
 
 namespace stempy {
 
-std::pair<double, double> calculateThresholds(std::vector<Block>& blocks,
-                                              Image<double>& darkreference,
-                                              int numberOfSamples = 20,
-                                              double backgroundThresholdNSigma = 4,
-                                              double xRayThresholdNSigma = 10);
+std::pair<double, double> calculateThresholds(
+  std::vector<Block>& blocks, Image<double>& darkreference,
+  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10, bool verbose = false);
 }
 
 #endif /* STEMPY_ELECTRONTHRESHOLDS_H_ */


### PR DESCRIPTION
The verbose option causes the electron threshold function
to print out to the console a variety of variables. These
are the current variables that are printed out:

```
numberOfSamples
min
max
mean
variance
stdDev
numberOfBins
xRayThresholdNSigma
backgroundThresholdNSigma
xrayThreshold
backgroundThreshold
```

Fixes: #76