### PR TITLE
Add electron MPI example

### DIFF
--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -93,20 +93,6 @@ def main(files, dark_file, center, inner_radii, outer_radii, output_file,
         io.save_electron_counts(output_file, global_frame_events, scan_width,
                                 scan_height, frame_width, frame_height)
 
-        # Save out the electron counted image
-        img = np.zeros((576, 576))
-
-        # Just sum the events for now
-        for frame in global_frame_events:
-            for pos in frame:
-                row = pos // 576
-                column = pos % 576
-                img[row][column] += 1
-
-        fig, ax = plt.subplots(figsize=(12, 12))
-        ax.matshow(img)
-        plt.savefig('electron.png', dpi=300)
-
         if generate_sparse:
             # Save out the sparse image
             width = electron_counted_data.scan_width

--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -25,9 +25,12 @@ def get_files(files):
               required=True)
 @click.option('-o', '--outer-radii', help='The outer radii (comma separated)',
               required=True)
+@click.option('-f', '--output-file', help='The output HDF5 file to write',
+              default='electron_counted_data.h5')
 @click.option('-g', '--generate-sparse', is_flag=True,
               help='Generate and save sparse STEM image')
-def main(files, dark_file, center, inner_radii, outer_radii, generate_sparse):
+def main(files, dark_file, center, inner_radii, outer_radii, output_file,
+         generate_sparse):
     center = center.split(',')
     if len(center) != 2:
         msg = 'Center must be of the form: center_x,center_y.'
@@ -80,7 +83,6 @@ def main(files, dark_file, center, inner_radii, outer_radii, generate_sparse):
         frame_width = electron_counted_data.frame_width
         frame_height = electron_counted_data.frame_height
 
-        output_file = 'electron_counted_data.h5'
         io.save_electron_counts(output_file, global_frame_events, scan_width,
                                 scan_height, frame_width, frame_height)
 

--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -51,6 +51,13 @@ def main(files, dark_file, center, inner_radii, outer_radii, output_file,
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     world_size = comm.Get_size()
+
+    if (world_size > len(files)):
+        if rank == 0:
+            print('Error: number of MPI processes,', world_size, ', exceeds',
+                  'the number of files:', len(files))
+        return
+
     comm.Barrier()
     start = MPI.Wtime()
 

--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -1,12 +1,10 @@
 from stempy import io, image
 
 import click
-import glob
 import matplotlib.pyplot as plt
 from mpi4py import MPI
 import numpy as np
-from pathlib import Path
-import sys
+
 
 def get_files(files):
     comm = MPI.COMM_WORLD
@@ -16,90 +14,115 @@ def get_files(files):
     return files[rank::world_size]
 
 
-comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
-world_size = comm.Get_size()
-comm.Barrier()
-start = MPI.Wtime()
+@click.command()
+@click.argument('files', nargs=-1,
+                type=click.Path(exists=True, dir_okay=False))
+@click.option('-d', '--dark-file', help='The file for dark field reference',
+              required=True)
+@click.option('-c', '--center', help='The center (comma separated)',
+              required=True)
+@click.option('-i', '--inner-radii', help='The inner radii (comma separated)',
+              required=True)
+@click.option('-o', '--outer-radii', help='The outer radii (comma separated)',
+              required=True)
+@click.option('-g', '--generate-sparse',
+              help='Generate and save sparse STEM image', default=False)
+def main(files, dark_file, center, inner_radii, outer_radii, generate_sparse):
+    center = center.split(',')
+    if len(center) != 2:
+        msg = 'Center must be of the form: center_x,center_y.'
+        raise click.ClickException(msg)
 
-# Every process will do the dark field reference average for now
-dark_file = '/data/scan_62/data_scan62_dst0_file0.data'
-reader = io.reader(dark_file, version=io.FileVersion.VERSION3)
-dark = image.calculate_average(reader)
+    center_x, center_y = [int(x) for x in center]
 
-all_files = glob.glob('/data/scan_30/*.data')
-files = get_files(all_files)
+    inner_radii = inner_radii.split(',')
+    outer_radii = outer_radii.split(',')
 
-# Create local electron count
-reader = io.reader(files, version=io.FileVersion.VERSION3)
-electron_counted_data = image.electron_count(reader, dark, verbose=True)
-local_frame_events = electron_counted_data.data
+    if len(inner_radii) != len(outer_radii):
+        msg = 'Number of inner and outer radii must match'
+        raise click.ClickException(msg)
 
-if rank == 0:
-    global_frame_events = local_frame_events
-else:
-    global_frame_events = None
+    inner_radii = [int(x) for x in inner_radii]
+    outer_radii = [int(x) for x in outer_radii]
 
-# Now reduce to root
-if world_size > 1:
-    if rank == 0:
-        # If comm.reduce() is used here instead, the empty numpy arrays
-        # in local_frame_events need to be replaced with np.array([0])
-        # so that they can be summed.
-        # Using comm.reduce() was found to take just a little longer on
-        # ulex than the method below.
-        # We may want to try comm.Reduce() sometime, but we will need
-        # to come up with a way to convert our array of variable length
-        # numpy arrays into a contiguous memory buffer.
-        for i in range(1, world_size):
-            data = comm.recv(source=i)
-            for j in range(data.shape[0]):
-                if len(data[j]) != 0:
-                    global_frame_events[j] = data[j]
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    world_size = comm.Get_size()
+    comm.Barrier()
+    start = MPI.Wtime()
+
+    # Every process will do the dark field reference average for now
+    reader = io.reader(dark_file, version=io.FileVersion.VERSION3)
+    dark = image.calculate_average(reader)
+
+    # Split up the files among processes
+    files = get_files(files)
+
+    # Create local electron count
+    reader = io.reader(files, version=io.FileVersion.VERSION3)
+    electron_counted_data = image.electron_count(reader, dark, verbose=True)
+    local_frame_events = electron_counted_data.data
+
+    # Now reduce to root
+    if world_size > 1:
+        if rank == 0:
+            global_frame_events = local_frame_events
+            # If comm.reduce() is used here instead, the empty numpy arrays
+            # in local_frame_events need to be replaced with np.array([0])
+            # so that they can be summed.
+            # Using comm.reduce() was found to take just a little longer on
+            # ulex than the method below.
+            # We may want to try comm.Reduce() sometime, but we will need
+            # to come up with a way to convert our array of variable length
+            # numpy arrays into a contiguous memory buffer.
+            for i in range(1, world_size):
+                data = comm.recv(source=i)
+                for j in range(data.shape[0]):
+                    if len(data[j]) != 0:
+                        global_frame_events[j] = data[j]
+        else:
+            comm.send(local_frame_events, dest=0)
     else:
-        comm.send(local_frame_events, dest=0)
-else:
-    global_frame_events = local_frame_events
+        global_frame_events = local_frame_events
 
-comm.Barrier()
-end = MPI.Wtime()
+    comm.Barrier()
+    end = MPI.Wtime()
 
-if rank == 0:
-    print('time: %s' % (end - start))
+    if rank == 0:
+        print('time: %s' % (end - start))
 
-if rank == 0:
-    # Save out the electron counted image
-    img = np.zeros((576, 576))
+    if rank == 0:
+        # Save out the electron counted image
+        img = np.zeros((576, 576))
 
-    # Just sum the events for now
-    for frame in global_frame_events:
-        for pos in frame:
-            row = pos // 576
-            column = pos % 576
-            img[row][column] += 1
+        # Just sum the events for now
+        for frame in global_frame_events:
+            for pos in frame:
+                row = pos // 576
+                column = pos % 576
+                img[row][column] += 1
 
-    fig,ax=plt.subplots(figsize=(12,12))
-    ax.matshow(img)
-    plt.savefig('electron.png', dpi=300)
+        fig, ax = plt.subplots(figsize=(12, 12))
+        ax.matshow(img)
+        plt.savefig('electron.png', dpi=300)
 
-    # Save out the sparse image
-    width = electron_counted_data.scan_width
-    height = electron_counted_data.scan_height
-    frame_width = electron_counted_data.frame_width
-    frame_height = electron_counted_data.frame_height
+        if generate_sparse:
+            # Save out the sparse image
+            width = electron_counted_data.scan_width
+            height = electron_counted_data.scan_height
+            frame_width = electron_counted_data.frame_width
+            frame_height = electron_counted_data.frame_height
 
-    inner_radius = 0
-    outer_radius = 50
-    center_x = 286
-    center_y = 314
-    stem_img = image.create_stem_image_sparse(global_frame_events,
-                                              inner_radius, outer_radius,
-                                              width=width, height=height,
-                                              frame_width=frame_width,
-                                              frame_height=frame_height,
-                                              center_x=center_x,
-                                              center_y=center_y)
+            stem_img = image.create_stem_images_sparse(
+                global_frame_events, inner_radii, outer_radii, width=width,
+                height=height, frame_width=frame_width,
+                frame_height=frame_height, center_x=center_x,
+                center_y=center_y)
 
-    fig,ax=plt.subplots(figsize=(12,12))
-    ax.matshow(stem_img)
-    plt.savefig('sparse_stem_image.png', dpi=300)
+            fig, ax = plt.subplots(figsize=(12, 12))
+            ax.matshow(stem_img)
+            plt.savefig('sparse_stem_image.png', dpi=300)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -74,6 +74,16 @@ def main(files, dark_file, center, inner_radii, outer_radii, generate_sparse):
         print('time: %s' % (end - start))
 
     if rank == 0:
+        # Write out the HDF5 file
+        scan_width = electron_counted_data.scan_width
+        scan_height = electron_counted_data.scan_height
+        frame_width = electron_counted_data.frame_width
+        frame_height = electron_counted_data.frame_height
+
+        output_file = 'electron_counted_data.h5'
+        io.save_electron_counts(output_file, global_frame_events, scan_width,
+                                scan_height, frame_width, frame_height)
+
         # Save out the electron counted image
         img = np.zeros((576, 576))
 

--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -1,0 +1,98 @@
+from stempy import io, image
+
+import click
+import glob
+import matplotlib.pyplot as plt
+from mpi4py import MPI
+import numpy as np
+from pathlib import Path
+import sys
+
+def get_files(files):
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    world_size = comm.Get_size()
+
+    return files[rank::world_size]
+
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+world_size = comm.Get_size()
+comm.Barrier()
+start = MPI.Wtime()
+
+# Every process will do the dark field reference average for now
+dark_file = '/data/scan_62/data_scan62_dst0_file0.data'
+reader = io.reader(dark_file, version=io.FileVersion.VERSION3)
+dark = image.calculate_average(reader)
+
+all_files = glob.glob('/data/scan_30/*.data')
+files = get_files(all_files)
+
+# Create local electron count
+reader = io.reader(files, version=io.FileVersion.VERSION3)
+electron_counted_data = image.electron_count(reader, dark, verbose=True)
+local_frame_events = electron_counted_data.data
+
+if rank == 0:
+    global_frame_events = local_frame_events
+else:
+    global_frame_events = None
+
+# Now reduce to root
+if world_size > 1:
+    if rank == 0:
+        for i in range(1, world_size):
+            data = comm.recv(source=i)
+            for j in range(data.shape[0]):
+                if len(data[j]) != 0:
+                    global_frame_events[j] = data[j]
+    else:
+        comm.send(local_frame_events, dest=0)
+else:
+    global_frame_events = local_frame_events
+
+
+comm.Barrier()
+end = MPI.Wtime()
+
+if rank == 0:
+    print('time: %s' % (end - start))
+
+if rank == 0:
+    # Save out the electron counted image
+    img = np.zeros((576, 576))
+
+    # Just sum the events for now
+    for frame in global_frame_events:
+        for pos in frame:
+            row = pos // 576
+            column = pos % 576
+            img[row][column] += 1
+
+    fig,ax=plt.subplots(figsize=(12,12))
+    ax.matshow(img)
+    plt.savefig('electron.png', dpi=300)
+
+    # Save out the sparse image
+    width = electron_counted_data.scan_width
+    height = electron_counted_data.scan_height
+    frame_width = electron_counted_data.frame_width
+    frame_height = electron_counted_data.frame_height
+
+    inner_radius = 0
+    outer_radius = 50
+    center_x = 286
+    center_y = 314
+    stem_img = image.create_stem_image_sparse(global_frame_events,
+                                              inner_radius, outer_radius,
+                                              width=width, height=height,
+                                              frame_width=frame_width,
+                                              frame_height=frame_height,
+                                              center_x=center_x,
+                                              center_y=center_y)
+
+    fig,ax=plt.subplots(figsize=(12,12))
+    ax.matshow(stem_img)
+    plt.savefig('sparse_stem_image.png', dpi=300)


### PR DESCRIPTION
This is an example of performing the electron counting using MPI. It seems to work, and it provides a decent speed increase as well.

One concern we had was that the background thresholds and x-ray thresholds may not be as accurate, because each MPI process can currently only sample from its own files. However, for our test dataset, it does not appear to produce a noticeable difference.

Timings are interesting. On ulex, with `OMP_NUM_THREADS=1`, vtkm with openmp, and disk caching in use, these are the timing results:
```
Num MPI Processes: Seconds
1: 66.93
2: 66.80
4: 33.42
8: 19.14
```

* Note for our example, we have 8 files. Four of the files are 2.5 GB, and four are 100 MB. The lack of improvement from one MPI process to two is because one process is reading/processing all of the large files, and the other process is reading/processing all the small files.