### PR TITLE
Do not expand sparse data for sparse stem images

### DIFF
--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -343,8 +343,9 @@ void calculateSTEMValuesSparse(const vector<vector<uint32_t>>& data,
 {
   for (unsigned i = 0; i < data.size(); ++i) {
     uint64_t values = 0;
-    for (auto pos : data[i])
+    for (auto pos : data[i]) {
       values += mask[pos];
+    }
     image.data[i] = values;
   }
 }


### PR DESCRIPTION
When the sparse stem image functions were originally created, they
expanded the sparse data so that they could re-use functions that
are used by regular stem images. This, however, creates a very large
copy for some datasets.

This modification avoids that expansion and simplifies sparse stem
image creation. It should, in theory, be faster as well.