### PR TITLE
Use tuples and std::pair for dimensions and points

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+To build the docs, first install the requirements in the `docs/`
+directory via:
+
+```
+pip install -r requirements.txt
+```
+
+Then, run the bash script in the `docs/` directory:
+
+```
+./run_sphinx.sh
+```
+
+The sphinx html documentation will be built and placed inside the
+`build` directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+pygments

--- a/docs/run_sphinx.sh
+++ b/docs/run_sphinx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# We use --implict-namespaces here so that 'stempy.' prepends the
+# module names. Otherwise, it will do things like 'import io', which
+# imports the system 'io' library rather than 'stempy.io'.
+# Extra arguments at the end are exclude patterns
+sphinx-apidoc --implicit-namespaces -f -o source/ ../python/stempy ../python/stempy/pipeline
+
+make html

--- a/docs/run_sphinx.sh
+++ b/docs/run_sphinx.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Clean up the current documentation
+make clean html
+
 # We use --implict-namespaces here so that 'stempy.' prepends the
 # module names. Otherwise, it will do things like 'import io', which
 # imports the system 'io' library rather than 'stempy.io'.

--- a/docs/source/StempyH5Format.rst
+++ b/docs/source/StempyH5Format.rst
@@ -1,0 +1,61 @@
+
+Stempy H5 Format
+================
+
+This file is present to keep a record of the current layout of
+the stempy H5 format.
+
+Currently, the structure of the format is as follows:
+
+.. code-block::
+
+   electron_events
+   ├── frames
+   └── scan_positions
+   stem
+   └── images
+   frames
+
+
+* 
+  ``electron_events/frames`` - Array of arrays, the first index is the scan position
+  ( corresponding to ``scan_positions`` ) and the second array holds an array of
+  of indices into the diffractogram where an electron strike was detected.
+
+
+  * Attributes:
+
+    * ``Nx``\ : the width of the frame
+    * ``Ny``\ : the height of the frame
+
+* 
+  ``electron_events/scan_positions`` - Array of shorts holding the scan positions.
+
+
+  * Attributes:
+
+    * ``Nx``\ : the width of the scan
+    * ``Ny``\ : the height of the scan
+
+* 
+  ``stem/images`` - A list of 2D arrays of unsigned integers containing stem images
+  (possibly bright and dark fields).
+
+
+  * Attributes:
+
+    * ``names``\ : a list of names assigned to the images
+
+* 
+  ``frames`` - If present, the raw diffractogram data, where the first index is the scan
+  position index for the 2D diffractogram.
+
+This file can be produced with the script at ``examples/create_hdf5.py``
+by using a command similar to the following:
+
+.. code-block::
+
+   python create_hdf5.py -h 40 -w 40 -v 2 -x 2 -d /data/4dstem/electronCounting/stem4d_0000000235_0000000001.dat /data/4dstem/electronCounting/stem4d_0000000236_0000000009.dat --save-raw
+
+Use ``python create_hdf5.py --help`` for more information about the
+options.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,54 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../python/stempy'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'stempy'
+copyright = '2020, Kitware, INC'
+author = 'Kitware, INC'
+
+# The full version, including alpha/beta/rc tags
+release = '1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinx.ext.autodoc']
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,3 +52,29 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+
+# Modify this function to customize which classes/functions are skipped
+def autodoc_skip_member_handler(app, what, name, obj, skip, options):
+    # Exclude any names that start with a string in this list
+    exclude_startswith_list = ['_']
+
+    if any([name.startswith(x) for x in exclude_startswith_list]):
+        return True
+
+    # Exclude any names that match a string in this list
+    exclude_names = [
+        'ReaderMixin',
+        'PyReader',
+        'SectorReader',
+        'get_hdf5_reader'
+    ]
+
+    return name in exclude_names
+
+
+# Automatically called by sphinx at startup
+def setup(app):
+    # Connect the autodoc-skip-member event from apidoc to the callback
+    # This allows us to customize which classes/functions are skipped
+    app.connect('autodoc-skip-member', autodoc_skip_member_handler)

--- a/docs/source/conventions.rst
+++ b/docs/source/conventions.rst
@@ -1,0 +1,14 @@
+Conventions
+===========
+
+Coordinate Conventions
+----------------------
+
+In stempy conventions, the origin is located at the top left corner of
+the image. Moving right and down increases x and y, respectively.
+
+For points, such as a `center`, the stempy convention is for it to be a
+tuple of `(x, y)` coordinates.
+
+For dimensions, such as `scan_dimensions` or `frame_dimensions`, the
+stempy convention is for it to be a tuple of `(width, height)`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. stempy documentation master file, created by
+   sphinx-quickstart on Wed Jan 22 11:51:34 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to stempy's documentation!
+==================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,8 @@ Welcome to stempy's documentation!
 
    modules
 
+   conventions.rst
+
 Indices and tables
 ==================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,8 @@ Welcome to stempy's documentation!
 
    conventions.rst
 
+   StempyH5Format.rst
+
 Indices and tables
 ==================
 

--- a/examples/benchmark_electron_counting.py
+++ b/examples/benchmark_electron_counting.py
@@ -31,8 +31,7 @@ def run_benchmarks(files, dark_sample, num_runs):
         dark = image.calculate_average(reader)
 
         reader = io.reader(files, version=io.FileVersion.VERSION2)
-        data = image.electron_count(reader, dark, scan_width=40,
-                                    scan_height=40)
+        data = image.electron_count(reader, dark, scan_dimensions=(40, 40))
 
         end = time.time()
         times.append(end - start)

--- a/examples/benchmark_stem_image.py
+++ b/examples/benchmark_stem_image.py
@@ -22,7 +22,8 @@ def run_benchmarks(files, num_runs):
         start = time.time()
 
         reader = io.reader(files)
-        img = image.create_stem_image(reader, 40, 288, width=160, height=160)
+        img = image.create_stem_image(reader, 40, 288,
+                                      scan_dimensions=(160, 160))
 
         end = time.time()
         times.append(end - start)

--- a/examples/create_hdf5.py
+++ b/examples/create_hdf5.py
@@ -45,16 +45,16 @@ def make_stem_hdf5(files, dark_sample, width, height, inner_radius,
     else:
         sys.exit('Unknown dark reader version:', dark_reader_version)
 
+    scan_dimensions = (width, height)
+
     reader = io.reader(dark_sample, version=dark_reader_version)
     dark = image.calculate_average(reader)
 
     reader = io.reader(files, version=reader_version)
-    data = image.electron_count(reader, dark, scan_width=width,
-                                scan_height=height)
+    data = image.electron_count(reader, dark, scan_dimensions=scan_dimensions)
 
     frame_events = data.data
-    detector_nx = data.frame_height
-    detector_ny = data.frame_width
+    frame_dimensions = data.frame_dimensions
 
     inner_radii = [0, inner_radius]
     outer_radii = [outer_radius, outer_radius]
@@ -62,10 +62,10 @@ def make_stem_hdf5(files, dark_sample, width, height, inner_radius,
 
     reader.reset()
     imgs = image.create_stem_images(reader, inner_radii, outer_radii,
-                                    width=width, height=height)
+                                    scan_dimensions=scan_dimensions)
 
-    io.save_electron_counts(output, frame_events, width, height, detector_nx,
-                            detector_ny)
+    io.save_electron_counts(output, frame_events, scan_dimensions,
+                            frame_dimensions)
     io.save_stem_images(output, imgs, names)
 
     if save_raw:

--- a/examples/electron.ipynb
+++ b/examples/electron.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "reader = io.reader('/data/scan_0000000236/stem4d_0000000236_0000000009.dat', version=io.FileVersion.VERSION2)\n",
-    "electron_counted_data = image.electron_count(reader, dark, scan_width=40, scan_height=40)\n",
+    "electron_counted_data = image.electron_count(reader, dark, scan_dimensions=(40, 40))\n",
     "frame_events = electron_counted_data.data"
    ]
   },

--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -36,7 +36,7 @@ def main(files, dark_file, center, inner_radii, outer_radii, output_file,
         msg = 'Center must be of the form: center_x,center_y.'
         raise click.ClickException(msg)
 
-    center_x, center_y = [int(x) for x in center]
+    center = tuple(int(x) for x in center)
 
     inner_radii = inner_radii.split(',')
     outer_radii = outer_radii.split(',')
@@ -85,26 +85,19 @@ def main(files, dark_file, center, inner_radii, outer_radii, output_file,
 
     if rank == 0:
         # Write out the HDF5 file
-        scan_width = electron_counted_data.scan_width
-        scan_height = electron_counted_data.scan_height
-        frame_width = electron_counted_data.frame_width
-        frame_height = electron_counted_data.frame_height
+        scan_dimensions = electron_counted_data.scan_dimensions
+        frame_dimensions = electron_counted_data.frame_dimensions
 
-        io.save_electron_counts(output_file, global_frame_events, scan_width,
-                                scan_height, frame_width, frame_height)
+        io.save_electron_counts(output_file, global_frame_events,
+                                scan_dimensions, frame_dimensions)
 
         if generate_sparse:
             # Save out the sparse image
-            width = electron_counted_data.scan_width
-            height = electron_counted_data.scan_height
-            frame_width = electron_counted_data.frame_width
-            frame_height = electron_counted_data.frame_height
 
             stem_imgs = image.create_stem_images_sparse(
-                global_frame_events, inner_radii, outer_radii, width=width,
-                height=height, frame_width=frame_width,
-                frame_height=frame_height, center_x=center_x,
-                center_y=center_y)
+                global_frame_events, inner_radii, outer_radii,
+                scan_dimensions=scan_dimensions,
+                frame_dimensions=frame_dimensions, center=center)
 
             for i, img in enumerate(stem_imgs):
                 fig, ax = plt.subplots(figsize=(12, 12))

--- a/examples/electron_stem_image.py
+++ b/examples/electron_stem_image.py
@@ -4,11 +4,11 @@ from stempy import io, image
 import numpy as np
 from PIL import Image
 
-def save_img(stem_image_data, name, width, height):
+def save_img(stem_image_data, name, scan_dimensions):
     min = np.min(stem_image_data)
     max = np.max(stem_image_data)
 
-    stem_image_data = stem_image_data.reshape((width, height))
+    stem_image_data = stem_image_data.reshape(scan_dimensions)
     stem_image_data = np.interp(stem_image_data, [min, max], [0, 256])
     stem_image_data = stem_image_data.astype(np.uint8)
     img = Image.fromarray(stem_image_data)
@@ -17,20 +17,17 @@ def save_img(stem_image_data, name, width, height):
 with h5py.File('stem_image.h5', 'r') as rf:
     frames = rf['/electron_events/frames'][()]
     attrs = rf['/electron_events/frames'].attrs
-    frame_width = attrs['Nx']
-    frame_height = attrs['Ny']
+    frame_dimensions = (attrs['Nx'], attrs['Ny'])
 
     attrs = rf['/electron_events/scan_positions'].attrs
-    scan_width = attrs['Nx']
-    scan_height = attrs['Ny']
+    scan_dimensions = (attrs['Nx'], attrs['Ny'])
 
-num_pixels = frame_width * frame_height
+num_pixels = frame_dimensions[0] * frame_dimensions[1]
 
 inner_radius = 40
 outer_radius = 288
 
 img = image.create_stem_image_sparse(frames, inner_radius, outer_radius,
-                                     scan_width, scan_height, frame_width,
-                                     frame_height)
+                                     scan_dimensions, frame_dimensions)
 
-save_img(img, 'img.png', scan_width, scan_height)
+save_img(img, 'img.png', scan_dimensions)

--- a/examples/hdf5Reader/reader_hdf5.py
+++ b/examples/hdf5Reader/reader_hdf5.py
@@ -24,7 +24,8 @@ h5file= h5py.File(filename, 'r')
 inner_radii = [0, 40]
 outer_radii = [288, 288]
 
-imgs = image.create_stem_images(h5file, inner_radii, outer_radii, width=160, height=160)
+imgs = image.create_stem_images(h5file, inner_radii, outer_radii,
+                                scan_dimensions=(160, 160))
 
 for i, img in enumerate(imgs):
     suffix = str(inner_radii[i]) + '_' + str(outer_radii[i]) + '.png'

--- a/examples/radial.ipynb
+++ b/examples/radial.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "reader = io.reader(files)\n",
-    "sum = image.radial_sum(reader, scan_width=160, scan_height=160)"
+    "sum = image.radial_sum(reader, scan_dimensions=(160, 160))"
    ]
   },
   {

--- a/examples/stem_histogram.ipynb
+++ b/examples/stem_histogram.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "reader = io.reader(files)\n",
     "all_bins, all_freqs = image.create_stem_histogram(num_bins, reader, inner_radii, outer_radii,\n",
-    "                                                  width=160, height=160)"
+    "                                                  scan_dimensions=(160, 160))"
    ]
   },
   {

--- a/examples/stem_histogram.py
+++ b/examples/stem_histogram.py
@@ -53,7 +53,7 @@ def main(argv):
     numBins = 100
     print('Generating histograms for input data')
     all_bins, all_freqs = image.create_stem_histogram(numBins, reader, inner_radii, outer_radii,
-                                                    width=160, height=160)
+                                                    scan_dimensions=(160, 160))
 
     # plot histogram
     for i in range(len(all_bins)):

--- a/examples/stem_image.ipynb
+++ b/examples/stem_image.ipynb
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "reader = io.reader(files)\n",
-    "imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160, height=160)"
+    "imgs = image.create_stem_images(reader, inner_radii, outer_radii, scan_dimensions=(160, 160))"
    ]
   },
   {

--- a/examples/stem_image.py
+++ b/examples/stem_image.py
@@ -25,8 +25,8 @@ inner_radii = [0, 40]
 outer_radii = [288, 288]
 
 reader = io.reader(files)
-imgs = image.create_stem_images(reader, inner_radii, outer_radii, width=160,
-                                height=160)
+imgs = image.create_stem_images(reader, inner_radii, outer_radii,
+                                scan_dimensions=(160, 160))
 
 for i, img in enumerate(imgs):
     suffix = str(inner_radii[i]) + '_' + str(outer_radii[i]) + '.png'

--- a/python/io.cpp
+++ b/python/io.cpp
@@ -13,28 +13,27 @@ PYBIND11_MODULE(_io, m)
 {
   py::class_<Header>(m, "_header")
     .def_readonly("images_in_block", &Header::imagesInBlock)
-    .def_readonly("frame_height", &Header::frameHeight)
-    .def_readonly("frame_width", &Header::frameWidth)
+    .def_readonly("frame_dimensions", &Header::frameDimensions)
     .def_readonly("version", &Header::version)
     .def_readonly("timestamp", &Header::timestamp)
     .def_readonly("image_numbers", &Header::imageNumbers)
-    .def_readonly("scan_height", &Header::scanHeight)
-    .def_readonly("scan_width", &Header::scanWidth);
+    .def_readonly("scan_dimensions", &Header::scanDimensions);
 
   py::class_<Block>(m, "_block", py::buffer_protocol())
     .def_readonly("header", &Block::header)
     .def_buffer([](Block& b) {
       return py::buffer_info(
-        b.data.get(),     /* Pointer to buffer */
-        sizeof(uint16_t), /* Size of one scalar */
-        py::format_descriptor<
-          uint16_t>::format(), /* Python struct-style format descriptor */
-        3,                     /* Number of dimensions */
-        { b.header.imagesInBlock, b.header.frameHeight,
-          b.header.frameWidth }, /* Buffer dimensions */
-        { sizeof(uint16_t) * b.header.frameHeight * b.header.frameWidth,
-          sizeof(uint16_t) *
-            b.header.frameHeight, /* Strides (in bytes) for each index */
+        b.data.get(),                              /* Pointer to buffer */
+        sizeof(uint16_t),                          /* Size of one scalar */
+        py::format_descriptor<uint16_t>::format(), /* Python struct-style format
+                                                      descriptor */
+        3,                                         /* Number of dimensions */
+        { b.header.imagesInBlock, b.header.frameDimensions.second,
+          b.header.frameDimensions.first }, /* Buffer dimensions */
+        { sizeof(uint16_t) * b.header.frameDimensions.second *
+            b.header.frameDimensions.first,
+          sizeof(uint16_t) * b.header.frameDimensions
+                               .second, /* Strides (in bytes) for each index */
           sizeof(uint16_t) });
     });
 
@@ -42,16 +41,17 @@ PYBIND11_MODULE(_io, m)
     .def_readonly("header", &PyBlock::header)
     .def_buffer([](PyBlock& b) {
       return py::buffer_info(
-        b.data.get(),     /* Pointer to buffer */
-        sizeof(uint16_t), /* Size of one scalar */
-        py::format_descriptor<
-          uint16_t>::format(), /* Python struct-style format descriptor */
-        3,                     /* Number of dimensions */
-        { b.header.imagesInBlock, b.header.frameHeight,
-          b.header.frameWidth }, /* Buffer dimensions */
-        { sizeof(uint16_t) * b.header.frameHeight * b.header.frameWidth,
-          sizeof(uint16_t) *
-            b.header.frameHeight, /* Strides (in bytes) for each index */
+        b.data.get(),                              /* Pointer to buffer */
+        sizeof(uint16_t),                          /* Size of one scalar */
+        py::format_descriptor<uint16_t>::format(), /* Python struct-style format
+                                                      descriptor */
+        3,                                         /* Number of dimensions */
+        { b.header.imagesInBlock, b.header.frameDimensions.second,
+          b.header.frameDimensions.first }, /* Buffer dimensions */
+        { sizeof(uint16_t) * b.header.frameDimensions.second *
+            b.header.frameDimensions.first,
+          sizeof(uint16_t) * b.header.frameDimensions
+                               .second, /* Strides (in bytes) for each index */
           sizeof(uint16_t) });
     });
 
@@ -72,8 +72,8 @@ PYBIND11_MODULE(_io, m)
     .def(py::init<PyReader*>());
 
   py::class_<PyReader>(m, "_pyreader")
-    .def(py::init<py::object, std::vector<uint32_t>&, uint32_t, uint32_t,
-                  uint32_t, uint32_t>())
+    .def(py::init<py::object, std::vector<uint32_t>&, Dimensions2D, uint32_t,
+                  uint32_t>())
     .def("read", (PyBlock(PyReader::*)()) & PyReader::read)
     .def("reset", &PyReader::reset)
     .def("begin", (PyReader::iterator(PyReader::*)()) & PyReader::begin)

--- a/python/pyreader.cpp
+++ b/python/pyreader.cpp
@@ -14,11 +14,11 @@ PyBlock::PyBlock(py::array_t<uint16_t> pyarray)
 }
 
 PyReader::PyReader(py::object pyDataSet, std::vector<uint32_t>& imageNumbers,
-                   uint32_t scanWidth, uint32_t scanHeight, uint32_t blockSize,
+                   Dimensions2D scanDimensions, uint32_t blockSize,
                    uint32_t totalImageNum)
   : m_pydataset(pyDataSet), m_imageNumbers(imageNumbers),
-    m_scanWidth(scanWidth), m_scanHeight(scanHeight),
-    m_imageNumInBlock(blockSize), m_totalImageNum(totalImageNum)
+    m_scanDimensions(scanDimensions), m_imageNumInBlock(blockSize),
+    m_totalImageNum(totalImageNum)
 {
 }
 
@@ -44,8 +44,7 @@ PyBlock PyReader::read()
   py::array_t<uint16_t> pyarray = getItems(sliceIndex);
 
   PyBlock b(pyarray);
-  uint32_t imageWidth = pyarray.shape()[2];
-  uint32_t imageHeight = pyarray.shape()[1];
+  Dimensions2D frameDimensions = { pyarray.shape()[2], pyarray.shape()[1] };
 
   // get the image numbers for current header
   std::vector<uint32_t> imageNumberForBlock;
@@ -53,8 +52,8 @@ PyBlock PyReader::read()
     imageNumberForBlock.push_back(m_imageNumbers[i]);
   }
 
-  b.header = Header(imageWidth, imageHeight, m_imageNumInBlock, m_scanWidth,
-                    m_scanHeight, imageNumberForBlock);
+  b.header = Header(frameDimensions, m_imageNumInBlock, m_scanDimensions,
+                    imageNumberForBlock);
   b.header.version = 3;
 
   m_currIndex = upperBound;

--- a/python/pyreader.h
+++ b/python/pyreader.h
@@ -34,7 +34,7 @@ class PYBIND11_EXPORT PyReader
 
 public:
   PyReader(py::object pyDataSet, std::vector<uint32_t>& imageNumbers,
-           uint32_t scanWidth, uint32_t scanHeight, uint32_t blockSize,
+           Dimensions2D scanDimensions, uint32_t blockSize,
            uint32_t totalImageNum);
 
   PyBlock read();
@@ -98,10 +98,9 @@ public:
 
 private:
   py::object m_pydataset;
+  Dimensions2D m_scanDimensions;
   std::vector<uint32_t> m_imageNumbers;
   uint32_t m_currIndex = 0;
-  uint32_t m_scanWidth;
-  uint32_t m_scanHeight;
   uint32_t m_imageNumInBlock;
   uint32_t m_blockNumInFile;
   uint32_t m_totalImageNum;

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -7,6 +7,29 @@ from stempy.io import get_hdf5_reader
 
 def create_stem_images(input, inner_radii, outer_radii, scan_dimensions=(0, 0),
                        center=(-1, -1)):
+    """Create a series of stem images from the input.
+
+    :param input: the file reader that has already opened the data.
+    :type input: stempy.io.reader or an h5py file
+    :param inner_radii: a list of inner radii. Must match
+                        the length of `outer_radii`.
+    :type inner_radii: list of ints
+    :param outer_radii: a list of outer radii. Must match
+                        the length of `inner_radii`.
+    :type outer_radii: list of ints
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height). If set to (0, 0), an attempt
+                            will be made to read the scan dimensions from
+                            the data file.
+    :type scan_dimensions: tuple of ints of length 2
+    :param center: the center of the images, where the order is (x, y). If set
+                   to (-1, -1), the center will be set to
+                   (scan_dimensions[0] / 2, scan_dimensions[1] / 2).
+    :type center: tuple of ints of length 2
+
+    :return: A numpy array of the STEM images.
+    :rtype: numpy.ndarray
+    """
     # check if the input is the hdf5 dataset
     if(isinstance(input, h5py._hl.files.File)):
         reader = get_hdf5_reader(input)
@@ -23,6 +46,30 @@ def create_stem_images(input, inner_radii, outer_radii, scan_dimensions=(0, 0),
 def create_stem_histogram(numBins, reader, inner_radii,
                           outer_radii, scan_dimensions=(0, 0),
                           center=(-1, -1)):
+    """Create a histogram of the stem images generated from the input.
+
+    :param numBins: the number of bins the histogram should have.
+    :param reader: the file reader that has already opened the data.
+    :type reader: stempy.io.reader
+    :param inner_radii: a list of inner radii. Must match
+                        the length of `outer_radii`.
+    :type inner_radii: list of ints
+    :param outer_radii: a list of outer radii. Must match
+                        the length of `inner_radii`.
+    :type outer_radii: list of ints
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height). If set to (0, 0), an attempt
+                            will be made to read the scan dimensions from
+                            the data file.
+    :type scan_dimensions: tuple of ints of length 2
+    :param center: the center of the images, where the order is (x, y). If set
+                   to (-1, -1), the center will be set to
+                   (scan_dimensions[0] / 2, scan_dimensions[1] / 2).
+    :type center: tuple of ints of length 2
+
+    :return: The bins and the frequencies of the histogram.
+    :rtype: a tuple of length 2 of lists
+    """
     # create stem images
     imgs = _image.create_stem_images(reader.begin(), reader.end(),
                                      inner_radii, outer_radii,
@@ -43,15 +90,60 @@ def create_stem_histogram(numBins, reader, inner_radii,
 # This one exists for backward compatibility
 def create_stem_image(reader, inner_radius, outer_radius,
                       scan_dimensions=(0, 0), center=(-1, -1)):
+    """Create a stem image from the input.
+
+    :param reader: the file reader that has already opened the data.
+    :type reader: stempy.io.reader or an h5py file
+    :param inner_radius: the inner radius to use.
+    :type inner_radius: int
+    :param outer_radius: the outer radius to use.
+    :type outer_radius: int
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height). If set to (0, 0), an attempt
+                            will be made to read the scan dimensions from
+                            the data file.
+    :type scan_dimensions: tuple of ints of length 2
+    :param center: the center of the image, where the order is (x, y). If set
+                   to (-1, -1), the center will be set to
+                   (scan_dimensions[0] / 2, scan_dimensions[1] / 2).
+    :type center: tuple of ints of length 2
+
+    :return: The STEM image that was generated.
+    :rtype: numpy.ndarray
+    """
     return create_stem_images(reader, (inner_radius,), (outer_radius,),
                               scan_dimensions, center)[0]
 
 def create_stem_images_sparse(data, inner_radii, outer_radii,
-                              scan_dimensions=(0, 0), frame_dimensions=(0, 0),
+                              scan_dimensions=None, frame_dimensions=None,
                               center=(-1, -1), frame_offset=0):
-    """
-    scan_dimensions and frame_dimensions are required if
-    "data" is of type np.ndarray.
+    """Create a series of stem images from sparsified data.
+
+    :param data: the input sparsified data.
+    :type data: ElectronCountedData or numpy.ndarray
+    :param inner_radii: a list of inner radii. Must match
+                        the length of `outer_radii`.
+    :type inner_radii: list of ints
+    :param outer_radii: a list of outer radii. Must match
+                        the length of `inner_radii`.
+    :type outer_radii: list of ints
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height). Required if `data` is a
+                            numpy.ndarray.
+    :type scan_dimensions: tuple of ints of length 2
+    :param frame_dimensions: the dimensions of each frame, where the order is
+                             (width, height). Required if `data` is a
+                             numpy.ndarray.
+    :type frame_dimensions: tuple of ints of length 2
+    :param center: the center of the images, where the order is (x, y). If set
+                   to (-1, -1), the center will be set to
+                   (scan_dimensions[0] / 2, scan_dimensions[1] / 2).
+    :type center: tuple of ints of length 2
+    :param frame_offset: the amount by which to offset the frame.
+    :type frame_offset: int
+
+    :return: A numpy array of the STEM images.
+    :rtype: numpy.ndarray
     """
     if not isinstance(data, np.ndarray):
         # Assume it is an ElectronCountedData named tuple
@@ -68,8 +160,34 @@ def create_stem_images_sparse(data, inner_radii, outer_radii,
     return np.array(images, copy=False)
 
 def create_stem_image_sparse(data, inner_radius, outer_radius,
-                             scan_dimensions=(0, 0), frame_dimensions=(0, 0),
+                             scan_dimensions=None, frame_dimensions=None,
                              center=(-1, -1), frame_offset=0):
+    """Create a stem image from sparsified data.
+
+    :param data: the input sparsified data.
+    :type data: ElectronCountedData or numpy.ndarray
+    :param inner_radius: the inner radius to use.
+    :type inner_radius: int
+    :param outer_radius: the outer radius to use.
+    :type outer_radius: int
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height). Required if `data` is a
+                            numpy.ndarray.
+    :type scan_dimensions: tuple of ints of length 2
+    :param frame_dimensions: the dimensions of each frame, where the order is
+                             (width, height). Required if `data` is a
+                             numpy.ndarray.
+    :type frame_dimensions: tuple of ints of length 2
+    :param center: the center of the images, where the order is (x, y). If set
+                   to (-1, -1), the center will be set to
+                   (scan_dimensions[0] / 2, scan_dimensions[1] / 2).
+    :type center: tuple of ints of length 2
+    :param frame_offset: the amount by which to offset the frame.
+    :type frame_offset: int
+
+    :return: The STEM image that was generated.
+    :rtype: numpy.ndarray
+    """
     return create_stem_images_sparse(data, [inner_radius], [outer_radius],
                                      scan_dimensions, frame_dimensions, center,
                                      frame_offset)[0]
@@ -85,6 +203,14 @@ class ImageArray(np.ndarray):
         self._image = getattr(obj, '_image', None)
 
 def calculate_average(reader):
+    """Create an average image of all the images.
+
+    :param reader: the file reader that has already opened the data.
+    :type reader: stempy.io.reader
+
+    :return: The average image.
+    :rtype: stempy.image.ImageArray
+    """
     image =  _image.calculate_average(reader.begin(), reader.end())
     img = ImageArray(np.array(image, copy = False))
     img._image = image
@@ -95,7 +221,35 @@ def electron_count(reader, darkreference, number_of_samples=40,
                    background_threshold_n_sigma=4, xray_threshold_n_sigma=10,
                    threshold_num_blocks=1, scan_dimensions=(0, 0),
                    verbose=False):
+    """Generate a list of coordinates of electron hits.
 
+    :param reader: the file reader that has already opened the data.
+    :type reader: stempy.io.reader
+    :param darkreference: the dark reference to subtract, potentially generated
+                          via stempy.image.calculate_average().
+    :type darkreference: stempy.image.ImageArray or stempy::Image<double>
+    :param number_of_samples: the number of samples to take when calculating
+                              the thresholds.
+    :type number_of_samples: int
+    :param background_threshold_n_sigma: N-Sigma used for calculating the
+                                         background threshold.
+    :type background_threshold_n_sigma: int
+    :param xray_threshold_n_sigma: N-Sigma used for calculating the X-Ray
+                                   threshold
+    :type xray_threshold_n_sigma: int
+    :param threshold_num_blocks: The number of blocks of data to use when
+                                 calculating the threshold.
+    :type threshold_num_blocks: int
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height). Required if `data` is a
+                            numpy.ndarray.
+    :type scan_dimensions: tuple of ints of length 2
+    :param verbose: whether or not to print out verbose output.
+    :type verbose: bool
+
+    :return: the coordinates of the electron hits for each frame.
+    :rtype: ElectronCountedData (named tuple)
+    """
     blocks = []
     for i in range(threshold_num_blocks):
         blocks.append(next(reader))
@@ -149,6 +303,24 @@ def electron_count(reader, darkreference, number_of_samples=40,
     return electron_counted_data
 
 def radial_sum(reader, center=(-1, -1), scan_dimensions=(0, 0)):
+    """Generate a radial sum from which STEM images can be generated.
+
+    :param reader: the file reader that has already opened the data.
+    :type reader: stempy.io.reader
+    :param center: the center of the image, where the order is (x, y). If set
+                   to (-1, -1), the center will be set to
+                   (scan_dimensions[0] / 2, scan_dimensions[1] / 2).
+    :type center: tuple of ints of length 2
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height). If set to (0, 0), an attempt
+                            will be made to read the scan dimensions from
+                            the data file.
+    :type scan_dimensions: tuple of ints of length 2
+
+    :return: The generated radial sum.
+    :rtype: numpy.ndarray
+    """
+
     sum =  _image.radial_sum(reader.begin(), reader.end(), scan_dimensions,
                              center)
 
@@ -156,6 +328,17 @@ def radial_sum(reader, center=(-1, -1), scan_dimensions=(0, 0)):
 
 
 def maximum_diffraction_pattern(reader, darkreference=None):
+    """Generate an image of the maximum diffraction pattern.
+
+    :param reader: the file reader that has already opened the data.
+    :type reader: stempy.io.reader
+    :param darkreference: the dark reference to subtract, potentially generated
+                          via stempy.image.calculate_average().
+    :type darkreference: stempy.image.ImageArray or stempy::Image<double>
+
+    :return: the maximum diffraction pattern.
+    :rtype: stempy.image.ImageArray
+    """
     if darkreference is not None:
         darkreference = darkreference._image
         image = _image.maximum_diffraction_pattern(reader.begin(), reader.end(), darkreference)

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -137,8 +137,8 @@ std::vector<uint32_t> maximalPoints(const std::vector<uint16_t>& frame,
   std::vector<uint32_t> events;
   auto numberOfPixels = height * width;
   for (int i = 0; i < numberOfPixels; i++) {
-    int row = i / width;
-    int column = i % width;
+    auto row = i / width;
+    auto column = i % width;
     auto rightNeighbourColumn = mod((i + 1), width);
     auto leftNeighbourColumn = mod((i - 1), width);
     auto topNeighbourRow = mod((row - 1), height);
@@ -148,26 +148,45 @@ std::vector<uint32_t> maximalPoints(const std::vector<uint16_t>& frame,
     auto topNeighbourRowIndex = topNeighbourRow * width;
     auto rowIndex = row * width;
 
-    // top
-    auto event = pixelValue > frame[topNeighbourRowIndex + column];
-    // top right
-    event =
-      event && pixelValue > frame[topNeighbourRowIndex + rightNeighbourColumn];
-    // right
-    event = event && pixelValue > frame[rowIndex + rightNeighbourColumn];
-    // bottom right
-    event = event &&
-            pixelValue > frame[bottomNeighbourRowIndex + rightNeighbourColumn];
-    // bottom
-    event = event && pixelValue > frame[bottomNeighbourRowIndex + column];
-    // bottom left
-    event = event &&
-            pixelValue > frame[bottomNeighbourRowIndex + leftNeighbourColumn];
+    auto event = true;
+
+    // If we are on row 0, there are no pixels above this one
+    if (row != 0) {
+      // Check top sections
+      // top
+      event = event && pixelValue > frame[topNeighbourRowIndex + column];
+      // top left
+      event = event &&
+              (column == 0 ||
+               pixelValue > frame[topNeighbourRowIndex + leftNeighbourColumn]);
+      // top right
+      event = event &&
+              (column == width - 1 ||
+               pixelValue > frame[topNeighbourRowIndex + rightNeighbourColumn]);
+    }
+
+    // If we are on the bottom row, there are no pixels below this one
+    if (event && row != height - 1) {
+      // Check bottom sections
+      // bottom
+      event = event && pixelValue > frame[bottomNeighbourRowIndex + column];
+      // bottom left
+      event = event && (column == 0 ||
+                        pixelValue >
+                          frame[bottomNeighbourRowIndex + leftNeighbourColumn]);
+      // bottom right
+      event =
+        event &&
+        (column == width - 1 ||
+         pixelValue > frame[bottomNeighbourRowIndex + rightNeighbourColumn]);
+    }
+
     // left
-    event = event && pixelValue > frame[rowIndex + leftNeighbourColumn];
-    // top left
-    event =
-      event && pixelValue > frame[topNeighbourRowIndex + leftNeighbourColumn];
+    event = event &&
+            (column == 0 || pixelValue > frame[rowIndex + leftNeighbourColumn]);
+    // right
+    event = event && (column == width - 1 ||
+                      pixelValue > frame[rowIndex + rightNeighbourColumn]);
 
     if (event) {
       events.push_back(i);

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -9,26 +9,23 @@ struct ElectronCountedData
 {
   std::vector<std::vector<uint32_t>> data;
 
-  // These types match those of the Header class
-  uint16_t scanWidth = 0;
-  uint16_t scanHeight = 0;
-  uint32_t frameWidth = 0;
-  uint32_t frameHeight = 0;
+  Dimensions2D scanDimensions = { 0, 0 };
+  Dimensions2D frameDimensions = { 0, 0 };
 };
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
                                   Image<double>& darkreference,
                                   double backgroundThreshold,
-                                  double xRayThreshold, int scanWidth = 0,
-                                  int scanHeight = 0);
+                                  double xRayThreshold,
+                                  Dimensions2D scanDimensions = { 0, 0 });
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
                                   const double darkreference[],
                                   double backgroundThreshold,
-                                  double xRayThreshold, int scanWidth = 0,
-                                  int scanHeight = 0);
+                                  double xRayThreshold,
+                                  Dimensions2D scanDimensions = { 0, 0 });
 }
 
 #endif /* STEMPY_ELECTRON_H_ */

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -76,16 +76,15 @@ CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
                                                double backgroundThresholdNSigma,
                                                double xRayThresholdNSigma)
 {
-  auto frameWidth = blocks[0].header.frameWidth;
-  auto frameHeight = blocks[0].header.frameHeight;
-  auto numberOfPixels = frameWidth * frameHeight;
+  auto frameDimensions = blocks[0].header.frameDimensions;
+  auto numberOfPixels = frameDimensions.first * frameDimensions.second;
 
   // Setup random number engine
   std::random_device randomDevice;
   std::default_random_engine randomEngine(randomDevice());
 
   int numberSamplePixels =
-    frameWidth * frameHeight * numberOfSamples;
+    frameDimensions.first * frameDimensions.second * numberOfSamples;
   std::vector<int16_t> samples(numberSamplePixels, 0);
   for (int i = 0; i < numberOfSamples; i++) {
     std::uniform_int_distribution<int> randomBlockDist(0, blocks.size() - 1);

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -37,10 +37,11 @@ using std::vector;
 namespace stempy {
 
 template <typename T>
-Image<T>::Image(uint32_t w, uint32_t h)
-  : width(w), height(h), data(new T[w * h], std::default_delete<T[]>())
+Image<T>::Image(Dimensions2D dims)
+  : dimensions(dims),
+    data(new T[dims.first * dims.second], std::default_delete<T[]>())
 {
-  std::fill(this->data.get(), this->data.get() + width * height, 0);
+  std::fill(this->data.get(), this->data.get() + dims.first * dims.second, 0);
 }
 
 STEMValues calculateSTEMValues(const uint16_t data[], uint64_t offset,
@@ -58,10 +59,12 @@ STEMValues calculateSTEMValues(const uint16_t data[], uint64_t offset,
 }
 
 template <typename T>
-RadialSum<T>::RadialSum(uint32_t w, uint32_t h, uint32_t r)
-  : width(w), height(h), radii(r), data(new T[w * h * r], std::default_delete<T[]>())
+RadialSum<T>::RadialSum(Dimensions2D dims, uint32_t r)
+  : dimensions(dims), radii(r),
+    data(new T[dims.first * dims.second * r], std::default_delete<T[]>())
 {
-  std::fill(this->data.get(), this->data.get() + width * height * radii, 0);
+  std::fill(this->data.get(),
+            this->data.get() + dims.first * dims.second * radii, 0);
 }
 
 
@@ -166,8 +169,9 @@ void _runCalculateSTEMValues(const uint16_t data[],
 template <typename InputIt>
 vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
                                    const vector<int>& innerRadii,
-                                   const vector<int>& outerRadii, int width,
-                                   int height, int centerX, int centerY)
+                                   const vector<int>& outerRadii,
+                                   Dimensions2D scanDimensions,
+                                   Coordinates2D center)
 {
   if (first == last) {
     ostringstream msg;
@@ -188,13 +192,12 @@ vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
   }
 
   // If we haven't been provided with width and height, try the header.
-  if (width == 0 || height == 0) {
-    width = first->header.scanWidth;
-    height = first->header.scanHeight;
+  if (scanDimensions.first == 0 || scanDimensions.second == 0) {
+    scanDimensions = first->header.scanDimensions;
   }
 
   // Raise an exception if we still don't have valid width and height
-  if (width <= 0 || height <= 0) {
+  if (scanDimensions.first <= 0 || scanDimensions.second <= 0) {
     ostringstream msg;
     msg << "No scan image size provided.";
     throw invalid_argument(msg.str());
@@ -203,12 +206,11 @@ vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
   vector<STEMImage> images;
   for (const auto& r : innerRadii) {
     (void)r;
-    images.push_back(STEMImage(width, height));
+    images.push_back(STEMImage(scanDimensions));
   }
   // Get image size from first block
-  auto frameWidth = first->header.frameWidth;
-  auto frameHeight = first->header.frameHeight;
-  auto numberOfPixels = frameWidth * frameHeight;
+  auto frameDimensions = first->header.frameDimensions;
+  auto numberOfPixels = frameDimensions.first * frameDimensions.second;
 
   vector<uint16_t*> masks;
 
@@ -218,8 +220,8 @@ vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
 #endif
 
   for (size_t i = 0; i < innerRadii.size(); ++i) {
-    masks.push_back(createAnnularMask(frameWidth, frameHeight, innerRadii[i],
-                                      outerRadii[i], centerX, centerY));
+    masks.push_back(
+      createAnnularMask(frameDimensions, innerRadii[i], outerRadii[i], center));
 
 #ifdef VTKm
     maskHandles.push_back(
@@ -285,12 +287,12 @@ vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
 std::vector<double> getContainer(const STEMImage& inImage, const int numBins)
 {
   // information about input STEMImage
-  int width = inImage.width;
-  int height = inImage.height;
+  auto scanDimensions = inImage.dimensions;
   auto curData = inImage.data;
 
   auto result =
-    std::minmax_element(curData.get(), curData.get() + width * height);
+    std::minmax_element(curData.get(), curData.get() + scanDimensions.first *
+                                                         scanDimensions.second);
   double min = *result.first;
   double max = *result.second;
 
@@ -316,12 +318,11 @@ std::vector<int> createSTEMHistogram(const STEMImage& inImage,
   std::vector<int> frequencies(numBins, 0);
 
   // STEMImage info
-  int width = inImage.width;
-  int height = inImage.height;
+  auto scanDimensions = inImage.dimensions;
   auto curData = inImage.data;
 
   // get a histrogram
-  for (int i = 0; i < width * height; i++) {
+  for (int i = 0; i < scanDimensions.first * scanDimensions.second; i++) {
     auto value = curData[i];
     // check which bin it belongs to
     for (int j = 0; j < numBins; j++) {
@@ -353,8 +354,8 @@ void calculateSTEMValuesSparse(const vector<vector<uint32_t>>& data,
 
 vector<STEMImage> createSTEMImagesSparse(
   const vector<vector<uint32_t>>& sparseData, const vector<int>& innerRadii,
-  const vector<int>& outerRadii, int width, int height, int frameWidth,
-  int frameHeight, int centerX, int centerY, int frameOffset)
+  const vector<int>& outerRadii, Dimensions2D scanDimensions,
+  Dimensions2D frameDimensions, Coordinates2D center, int frameOffset)
 {
   if (innerRadii.empty() || outerRadii.empty()) {
     ostringstream msg;
@@ -371,9 +372,9 @@ vector<STEMImage> createSTEMImagesSparse(
   vector<STEMImage> images;
   vector<uint16_t*> masks;
   for (size_t i = 0; i < innerRadii.size(); ++i) {
-    images.push_back(STEMImage(width, height));
-    masks.push_back(createAnnularMask(frameWidth, frameHeight, innerRadii[i],
-                                      outerRadii[i], centerX, centerY));
+    images.push_back(STEMImage(scanDimensions));
+    masks.push_back(
+      createAnnularMask(frameDimensions, innerRadii[i], outerRadii[i], center));
   }
 
   for (size_t i = 0; i < masks.size(); ++i)
@@ -388,20 +389,19 @@ vector<STEMImage> createSTEMImagesSparse(
 vector<STEMImage> createSTEMImagesSparse(const ElectronCountedData& data,
                                          const vector<int>& innerRadii,
                                          const vector<int>& outerRadii,
-                                         int centerX, int centerY)
+                                         Coordinates2D center)
 {
-  return createSTEMImagesSparse(
-    data.data, innerRadii, outerRadii, data.scanWidth, data.scanHeight,
-    data.frameWidth, data.frameHeight, centerX, centerY);
+  return createSTEMImagesSparse(data.data, innerRadii, outerRadii,
+                                data.scanDimensions, data.frameDimensions,
+                                center);
 }
 
 template <typename InputIt>
 Image<double> calculateAverage(InputIt first, InputIt last)
 {
-  auto frameWidth = first->header.frameWidth;
-  auto frameHeight = first->header.frameHeight;
-  auto numDetectorPixels = frameWidth*frameHeight;
-  Image<double> image(frameWidth, frameHeight);
+  auto frameDimensions = first->header.frameDimensions;
+  auto numDetectorPixels = frameDimensions.first * frameDimensions.second;
+  Image<double> image(frameDimensions);
 
   std::fill(image.data.get(), image.data.get() + numDetectorPixels, 0.0);
   uint64_t numberOfImages = 0;
@@ -410,14 +410,16 @@ Image<double> calculateAverage(InputIt first, InputIt last)
     auto blockData = block.data.get();
     numberOfImages += block.header.imagesInBlock;
     for (unsigned i = 0; i < block.header.imagesInBlock; i++) {
-      auto numberOfPixels = block.header.frameHeight * block.header.frameWidth;
+      auto numberOfPixels = block.header.frameDimensions.first *
+                            block.header.frameDimensions.second;
       for (unsigned j = 0; j < numberOfPixels; j++) {
         image.data[j] += blockData[i*numberOfPixels+j];
       }
     }
   }
 
-  for (unsigned i = 0; i < frameHeight * frameWidth; i++) {
+  for (unsigned i = 0; i < frameDimensions.first * frameDimensions.second;
+       i++) {
     image.data[i] /= numberOfImages;
   }
 
@@ -428,21 +430,21 @@ double inline distance(int x1, int y1, int x2, int y2) {
   return sqrt(pow((x1 - x2), 2.0) + pow((y1 - y2), 2.0));
 }
 
-void radialSumFrame(int centerX, int centerY, const uint16_t data[],
-                    uint64_t offset, int frameWidth, int frameHeight,
+void radialSumFrame(Coordinates2D center, const uint16_t data[],
+                    uint64_t offset, Dimensions2D frameDimensions,
                     int imageNumber, RadialSum<uint64_t>& radialSum)
 {
-  auto numberOfPixels = frameWidth*frameHeight;
+  auto numberOfPixels = frameDimensions.first * frameDimensions.second;
   for (int i=0; i< numberOfPixels; i++) {
-    auto x = i % frameWidth;
-    auto y = i / frameWidth;
-    auto radius = static_cast<int>(
-        std::ceil(
-            distance(x, y, centerX, centerY)
-        )
-    );
+    auto x = i % frameDimensions.first;
+    auto y = i / frameDimensions.first;
+    auto radius =
+      static_cast<int>(std::ceil(distance(x, y, center.first, center.second)));
     // Use compiler intrinsic to ensure atomic add
-    auto address = radialSum.data.get() + radius*radialSum.width*radialSum.height + imageNumber;
+    auto address =
+      radialSum.data.get() +
+      radius * radialSum.dimensions.first * radialSum.dimensions.second +
+      imageNumber;
     __sync_fetch_and_add(address, data[offset + i]);
   }
 }
@@ -490,12 +492,12 @@ void radialSumFrame(const vtkm::Vec<int, 2>& center,
          data, radialSum);
 }
 
-void radialSumFrames(int centerX, int centerY, const uint16_t data[],
+void radialSumFrames(Coordinates2D center, const uint16_t data[],
                      int frameWidth, std::vector<uint32_t>& imageNumbers,
                      uint32_t numberOfPixels, uint32_t numberOfScanPositions,
                      vtkm::cont::ArrayHandle<vtkm::Int64>& radialSum)
 {
-  vtkm::Vec<int, 2> center = { centerX, centerY };
+  vtkm::Vec<int, 2> centerVec = { center.first, center.second };
   auto dataHandle =
     vtkm::cont::make_ArrayHandle(data, numberOfPixels * imageNumbers.size());
   // Use view to the array already transfered
@@ -505,14 +507,14 @@ void radialSumFrames(int centerX, int centerY, const uint16_t data[],
     auto view =
       vtkm::cont::make_ArrayHandleView(dataHandle, offset, numberOfPixels);
 
-    radialSumFrame(center, view, frameWidth, imageNumbers[i], numberOfScanPositions,
-                   radialSum);
+    radialSumFrame(centerVec, view, frameWidth, imageNumbers[i],
+                   numberOfScanPositions, radialSum);
   }
 }
 
 #else
-void radialSumFrames(int centerX, int centerY, const uint16_t data[],
-                     int frameWidth, int frameHeight,
+void radialSumFrames(Coordinates2D center, const uint16_t data[],
+                     Dimensions2D frameDimensions,
                      std::vector<uint32_t>& imageNumbers,
                      uint32_t numberOfPixels, RadialSum<uint64_t>& radialSum)
 {
@@ -520,16 +522,16 @@ void radialSumFrames(int centerX, int centerY, const uint16_t data[],
     // We need to ensure we are using int64_t to prevent overflow.
     auto offset = static_cast<int64_t>(i) * numberOfPixels;
     auto imageNumber = imageNumbers[i];
-    radialSumFrame(centerX, centerY, data, offset,
-        frameWidth, frameHeight, imageNumber, radialSum);
+    radialSumFrame(center, data, offset, frameDimensions, imageNumber,
+                   radialSum);
   }
 }
 #endif
 }
 
 template <typename InputIt>
-RadialSum<uint64_t> radialSum(InputIt first, InputIt last, int scanWidth, int scanHeight,
-      int centerX, int centerY)
+RadialSum<uint64_t> radialSum(InputIt first, InputIt last,
+                              Dimensions2D scanDimensions, Coordinates2D center)
 {
   if (first == last) {
     ostringstream msg;
@@ -538,36 +540,36 @@ RadialSum<uint64_t> radialSum(InputIt first, InputIt last, int scanWidth, int sc
   }
 
   // If we haven't been provided with width and height, try the header.
-  if (scanWidth == 0 || scanHeight == 0) {
-    scanWidth = first->header.scanWidth;
-    scanHeight = first->header.scanHeight;
+  if (scanDimensions.first == 0 || scanDimensions.second == 0) {
+    scanDimensions = first->header.scanDimensions;
   }
 
   // Raise an exception if we still don't have valid width and height
-  if (scanWidth <= 0 || scanHeight <= 0) {
+  if (scanDimensions.first <= 0 || scanDimensions.second <= 0) {
     ostringstream msg;
     msg << "No scan image size provided.";
     throw invalid_argument(msg.str());
   }
 
   // Get image size from first block
-  auto frameWidth = first->header.frameWidth;
-  auto frameHeight = first->header.frameHeight;
-  auto numberOfPixels = frameWidth * frameHeight;
+  auto frameDimensions = first->header.frameDimensions;
+  auto numberOfPixels = frameDimensions.first * frameDimensions.second;
 
   // Default the center if necessary
-  if (centerX < 0)
-    centerX = static_cast<int>(std::round(frameWidth / 2.0));
+  if (center.first < 0)
+    center.first = static_cast<int>(std::round(frameDimensions.first / 2.0));
 
-  if (centerY < 0)
-    centerY = static_cast<int>(std::round(frameHeight / 2.0));
+  if (center.second < 0)
+    center.second = static_cast<int>(std::round(frameDimensions.second / 2.0));
 
   // Calculate the maximum possible radius for the frame, the maximum distance
   // from all four corners
   double max = 0.0;
   for(int x=0; x<2; x++) {
     for(int y=0; y<2; y++) {
-      auto dist = distance(x*frameWidth, y*frameHeight, centerX, centerY);
+      auto dist =
+        distance(x * frameDimensions.first, y * frameDimensions.second,
+                 center.first, center.second);
       if (dist > max) {
         max = dist;
       }
@@ -582,14 +584,14 @@ RadialSum<uint64_t> radialSum(InputIt first, InputIt last, int scanWidth, int sc
   // 2 threads to be ideal.
   int numThreads = 2;
   ThreadPool pool(numThreads);
-  RadialSum<uint64_t> radialSum(scanWidth, scanHeight, maxRadius+1);
+  RadialSum<uint64_t> radialSum(scanDimensions, maxRadius + 1);
 
 #ifdef VTKm
   // We need the reinterpret_cast as vtkm currently doesn't support atomic
   // access for uint64.
   auto radialSumHandle = vtkm::cont::make_ArrayHandle(
     reinterpret_cast<vtkm::Int64*>(radialSum.data.get()),
-    radialSum.radii * radialSum.width * radialSum.height);
+    radialSum.radii * radialSum.dimensions.first * radialSum.dimensions.second);
 #endif
 
   // Populate the worker pool
@@ -602,11 +604,12 @@ RadialSum<uint64_t> radialSum(InputIt first, InputIt last, int scanWidth, int sc
     // lambda so that we can explicity delete the block. Otherwise,
     // the block will not be deleted until the threads are destroyed.
 #ifdef VTKm
-    auto numberOfScanPositions = radialSum.width * radialSum.height;
-    futures.emplace_back(pool.enqueue(
-      [b, numberOfPixels, centerX, centerY, frameWidth,
-       &radialSumHandle, numberOfScanPositions]() mutable {
-        radialSumFrames(centerX, centerY, b.data.get(), frameWidth,
+    auto numberOfScanPositions =
+      radialSum.dimensions.first * radialSum.dimensions.second;
+    futures.emplace_back(
+      pool.enqueue([b, numberOfPixels, center, frameDimensions,
+                    &radialSumHandle, numberOfScanPositions]() mutable {
+        radialSumFrames(center, b.data.get(), frameDimensions.first,
                         b.header.imageNumbers, numberOfPixels,
                         numberOfScanPositions, radialSumHandle);
         // If we don't reset this, it won't get reset until the thread is
@@ -614,10 +617,10 @@ RadialSum<uint64_t> radialSum(InputIt first, InputIt last, int scanWidth, int sc
         b.data.reset();
       }));
 #else
-    futures.emplace_back(
-      pool.enqueue([b, numberOfPixels, centerX, centerY,  frameWidth, frameHeight, &radialSum]() mutable {
-        radialSumFrames(centerX, centerY, b.data.get(), frameWidth, frameHeight, b.header.imageNumbers,
-            numberOfPixels, radialSum);
+    futures.emplace_back(pool.enqueue(
+      [b, numberOfPixels, center, frameDimensions, &radialSum]() mutable {
+        radialSumFrames(center, b.data.get(), frameDimensions,
+                        b.header.imageNumbers, numberOfPixels, radialSum);
         // If we don't reset this, it won't get reset until the thread is
         // destroyed.
         b.data.reset();
@@ -636,10 +639,9 @@ template <typename InputIt>
 Image<double> maximumDiffractionPattern(InputIt first, InputIt last,
                                         const Image<double>& darkreference)
 {
-  auto frameWidth = first->header.frameWidth;
-  auto frameHeight = first->header.frameHeight;
-  auto numDetectorPixels = frameWidth * frameHeight;
-  Image<double> maxDiffPattern(frameWidth, frameHeight);
+  auto frameDimensions = first->header.frameDimensions;
+  auto numDetectorPixels = frameDimensions.first * frameDimensions.second;
+  Image<double> maxDiffPattern(frameDimensions);
 
   std::fill(maxDiffPattern.data.get(),
             maxDiffPattern.data.get() + numDetectorPixels, 0);
@@ -649,7 +651,8 @@ Image<double> maximumDiffractionPattern(InputIt first, InputIt last,
     auto blockData = block.data.get();
     numberOfImages += block.header.imagesInBlock;
     for (unsigned i = 0; i < block.header.imagesInBlock; i++) {
-      auto numberOfPixels = block.header.frameHeight * block.header.frameWidth;
+      auto numberOfPixels = block.header.frameDimensions.first *
+                            block.header.frameDimensions.second;
       for (unsigned j = 0; j < numberOfPixels; j++) {
         if (blockData[i * numberOfPixels + j] > maxDiffPattern.data[j]) {
           maxDiffPattern.data[j] = blockData[i * numberOfPixels + j];
@@ -659,7 +662,7 @@ Image<double> maximumDiffractionPattern(InputIt first, InputIt last,
   }
 
   // If we have been given a darkreference substract it
-  if (darkreference.width > 0) {
+  if (darkreference.dimensions.first > 0) {
     for (unsigned i = 0; i < numDetectorPixels; i++) {
       maxDiffPattern.data[i] -= darkreference.data[i];
     }
@@ -680,23 +683,23 @@ Image<double> maximumDiffractionPattern(InputIt first, InputIt last)
 // Instantiate the ones that can be used
 template vector<STEMImage> createSTEMImages<StreamReader::iterator>(
   StreamReader::iterator first, StreamReader::iterator last,
-  const vector<int>& innerRadii, const vector<int>& outerRadii, int width,
-  int height, int centerX, int centerY);
+  const vector<int>& innerRadii, const vector<int>& outerRadii,
+  Dimensions2D scanDimensions, Coordinates2D center);
 
 template vector<STEMImage> createSTEMImages<PyReader::iterator>(
   PyReader::iterator first, PyReader::iterator last,
-  const vector<int>& innerRadii, const vector<int>& outerRadii, int width,
-  int height, int centerX, int centerY);
+  const vector<int>& innerRadii, const vector<int>& outerRadii,
+  Dimensions2D scanDimensions, Coordinates2D center);
 
 template vector<STEMImage> createSTEMImages<vector<Block>::iterator>(
   vector<Block>::iterator first, vector<Block>::iterator last,
-  const vector<int>& innerRadii, const vector<int>& outerRadii, int width,
-  int height, int centerX, int centerY);
+  const vector<int>& innerRadii, const vector<int>& outerRadii,
+  Dimensions2D scanDimensions, Coordinates2D center);
 
 template vector<STEMImage> createSTEMImages<SectorStreamReader::iterator>(
   SectorStreamReader::iterator first, SectorStreamReader::iterator last,
-  const vector<int>& innerRadii, const vector<int>& outerRadii, int width,
-  int height, int centerX, int centerY);
+  const vector<int>& innerRadii, const vector<int>& outerRadii,
+  Dimensions2D scanDimensions, Coordinates2D center);
 
 template Image<double> calculateAverage(StreamReader::iterator first,
                                         StreamReader::iterator last);
@@ -707,19 +710,22 @@ template Image<double> calculateAverage(SectorStreamReader::iterator first,
 template Image<double> calculateAverage(PyReader::iterator first,
                                         PyReader::iterator last);
 
-
-template RadialSum<uint64_t> radialSum(StreamReader::iterator first, StreamReader::iterator last,
-      int scanWidth, int scanHeight, int centerX, int centerY);
-template RadialSum<uint64_t> radialSum(vector<Block>::iterator, vector<Block>::iterator last,
-      int scanWidth, int scanHeight, int centerX, int centerY);
+template RadialSum<uint64_t> radialSum(StreamReader::iterator first,
+                                       StreamReader::iterator last,
+                                       Dimensions2D scanDimensions,
+                                       Coordinates2D center);
+template RadialSum<uint64_t> radialSum(vector<Block>::iterator,
+                                       vector<Block>::iterator last,
+                                       Dimensions2D scanDimensions,
+                                       Coordinates2D center);
 template RadialSum<uint64_t> radialSum(SectorStreamReader::iterator first,
                                        SectorStreamReader::iterator last,
-                                       int scanWidth, int scanHeight,
-                                       int centerX, int centerY);
+                                       Dimensions2D scanDimensions,
+                                       Coordinates2D center);
 template RadialSum<uint64_t> radialSum(PyReader::iterator first,
                                        PyReader::iterator last,
-                                       int scanWidth, int scanHeight,
-                                       int centerX, int centerY);
+                                       Dimensions2D scanDimensions,
+                                       Coordinates2D center);
 
 template Image<double> maximumDiffractionPattern(
   StreamReader::iterator first, StreamReader::iterator last,

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -3,19 +3,19 @@
 
 #include "reader.h"
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 namespace stempy {
 
   template <typename T>
-  struct Image {
-    uint32_t width = 0;
-    uint32_t height = 0;
+  struct Image
+  {
+    Dimensions2D dimensions = { 0, 0 };
     std::shared_ptr<T[]> data;
 
     Image() = default;
-    Image(uint32_t width, uint32_t height);
+    Image(Dimensions2D dimensions);
     Image(Image&& i) noexcept = default;
     Image& operator=(Image&& i) noexcept = default;
   };
@@ -27,13 +27,12 @@ namespace stempy {
 
   template <typename T>
   struct RadialSum {
-    uint32_t width = 0;
-    uint32_t height = 0;
+    Dimensions2D dimensions = { 0, 0 };
     uint32_t radii = 0;
     std::shared_ptr<T[]> data;
 
     RadialSum() = default;
-    RadialSum(uint32_t width, uint32_t height, uint32_t radii);
+    RadialSum(Dimensions2D dimensions, uint32_t radii);
     RadialSum(RadialSum&& i) noexcept = default;
     RadialSum& operator=(RadialSum&& i) noexcept = default;
   };
@@ -41,22 +40,22 @@ namespace stempy {
   using STEMImage = Image<uint64_t>;
 
   template <typename InputIt>
-  std::vector<STEMImage> createSTEMImages(InputIt first, InputIt last,
-                                          const std::vector<int>& innerRadii,
-                                          const std::vector<int>& outerRadii,
-                                          int scanWidth = 0, int scanHeight = 0,
-                                          int centerX = -1, int centerY = -1);
+  std::vector<STEMImage> createSTEMImages(
+    InputIt first, InputIt last, const std::vector<int>& innerRadii,
+    const std::vector<int>& outerRadii, Dimensions2D scanDimensions = { 0, 0 },
+    Coordinates2D center = { -1, -1 });
 
   std::vector<STEMImage> createSTEMImagesSparse(
     const std::vector<std::vector<uint32_t>>& sparseData,
     const std::vector<int>& innerRadii, const std::vector<int>& outerRadii,
-    int rows, int columns, int frameWidth, int frameHeight, int centerX = -1,
-    int centerY = -1, int frameOffset = 0);
+    Dimensions2D scanDimensions = { 0, 0 },
+    Dimensions2D frameDimensions = { 0, 0 }, Coordinates2D center = { -1, -1 },
+    int frameOffset = 0);
 
   struct ElectronCountedData;
   std::vector<STEMImage> createSTEMImagesSparse(
     const ElectronCountedData& sparseData, const std::vector<int>& innerRadii,
-    const std::vector<int>& outerRadii, int centerX = -1, int centerY = -1);
+    const std::vector<int>& outerRadii, Coordinates2D center = { -1, -1 });
 
   STEMValues calculateSTEMValues(const uint16_t data[], uint64_t offset,
                                  uint32_t numberOfPixels, uint16_t mask[],
@@ -65,10 +64,10 @@ namespace stempy {
   template <typename InputIt>
   Image<double> calculateAverage(InputIt first, InputIt last);
 
-
   template <typename InputIt>
-  RadialSum<uint64_t> radialSum(InputIt first, InputIt last, int scanWidth = 0, int scanHeight = 0,
-        int centerX = -1, int centerY = -1);
+  RadialSum<uint64_t> radialSum(InputIt first, InputIt last,
+                                Dimensions2D scanDimensions = { 0, 0 },
+                                Coordinates2D center = { -1, -1 });
 
   // bins for histogram
   std::vector<double> getContainer(const STEMImage& inImage, const int numBins);
@@ -84,6 +83,6 @@ namespace stempy {
   template <typename InputIt>
   Image<double> maximumDiffractionPattern(InputIt first, InputIt last);
 
-  } // namespace stempy
+} // namespace stempy
 
 #endif

--- a/stempy/mask.cpp
+++ b/stempy/mask.cpp
@@ -6,26 +6,27 @@ using std::pow;
 
 namespace stempy {
 
-uint16_t* createAnnularMask(int width, int height, int innerRadius,
-                            int outerRadius, int centerX, int centerY)
+uint16_t* createAnnularMask(Dimensions2D dimensions, int innerRadius,
+                            int outerRadius, Coordinates2D center)
 {
-  auto numberOfElements = width*height;
+  auto numberOfElements = dimensions.first * dimensions.second;
   auto mask = new uint16_t[numberOfElements]();
 
-  if (centerX < 0)
-    centerX = round(width / 2.0);
+  if (center.first < 0)
+    center.first = round(dimensions.first / 2.0);
 
-  if (centerY < 0)
-    centerY = round(height / 2.0);
+  if (center.second < 0)
+    center.second = round(dimensions.second / 2.0);
 
   innerRadius = static_cast<int>(pow(innerRadius, 2.0));
   outerRadius = static_cast<int>(pow(outerRadius, 2.0));
 
   for (int i=0; i<numberOfElements; i++) {
-    auto x = i % width;
-    auto y = i / width;
+    // Ensure these are signed ints so we don't underflow below
+    int x = i % dimensions.first;
+    int y = i / dimensions.first;
 
-    auto d = pow((x - centerX), 2.0) + pow((y - centerY), 2.0);
+    auto d = pow((x - center.first), 2.0) + pow((y - center.second), 2.0);
     mask[i] = d >= innerRadius && d < outerRadius ? 0xFFFF : 0;
   }
 

--- a/stempy/mask.h
+++ b/stempy/mask.h
@@ -1,6 +1,8 @@
 #ifndef stempymask_h
 #define stempymask_h
 
+#include "reader.h"
+
 #include <iostream>
 #include <vector>
 #include <memory>
@@ -8,9 +10,8 @@
 
 namespace stempy {
 
-uint16_t* createAnnularMask(int width, int height, int innerRadius,
-                            int outerRadius, int centerX = -1,
-                            int centerY = -1);
+uint16_t* createAnnularMask(Dimensions2D dimensions, int innerRadius,
+                            int outerRadius, Coordinates2D center = { -1, -1 });
 }
 
 #endif

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -202,13 +202,12 @@ Header StreamReader::readHeaderVersion3()
   index = 0;
   read(headerPositions, 4 * sizeof(uint16_t));
 
-  // Note: The order is currently reversed y then x rather than the other way around
-  header.scanDimensions.second = headerPositions[index++];
   header.scanDimensions.first = headerPositions[index++];
+  header.scanDimensions.second = headerPositions[index++];
 
   // Now get the image numbers
-  auto scanYPosition = headerPositions[index++];
   auto scanXPosition = headerPositions[index++];
+  auto scanYPosition = headerPositions[index++];
   header.imageNumbers.push_back(scanYPosition * header.scanDimensions.first +
                                 scanXPosition);
 
@@ -333,12 +332,12 @@ Header SectorStreamReader::readHeader(std::ifstream& stream)
   index = 0;
   read(stream, headerPositions, 4 * sizeof(uint16_t));
 
-  header.scanDimensions.second = headerPositions[index++];
   header.scanDimensions.first = headerPositions[index++];
+  header.scanDimensions.second = headerPositions[index++];
 
   // Now get the image numbers
-  auto scanYPosition = headerPositions[index++];
   auto scanXPosition = headerPositions[index++];
+  auto scanYPosition = headerPositions[index++];
 
   header.imageNumbers.push_back(scanYPosition * header.scanDimensions.first +
                                 scanXPosition);

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -27,29 +27,24 @@ using std::vector;
 namespace stempy {
 
 /// Currently the detector data is written in four sectors
-const int SECTOR_WIDTH = 144;
-const int SECTOR_HEIGHT = 576;
+const Dimensions2D SECTOR_DIMENSIONS = { 144, 576 };
 
 /// This is the detector size at  NCEM
-const int FRAME_WIDTH = 576;
-const int FRAME_HEIGHT = 576;
+const Dimensions2D FRAME_DIMENSIONS = { 576, 576 };
 
-Header::Header(uint32_t frameWidth_, uint32_t frameHeight_,
-               uint32_t imageNumInBlock_, uint32_t scanWidth_,
-               uint32_t scanHeight_, vector<uint32_t>& imageNumbers_)
+Header::Header(Dimensions2D frameDimensions_, uint32_t imageNumInBlock_,
+               Dimensions2D scanDimensions_, vector<uint32_t>& imageNumbers_)
 {
-  this->frameWidth = frameWidth_;
-  this->frameHeight = frameHeight_;
+  this->frameDimensions = frameDimensions_;
   this->imagesInBlock = imageNumInBlock_;
-  this->scanHeight = scanHeight_;
-  this->scanWidth = scanWidth_;
+  this->scanDimensions = scanDimensions_;
   this->imageNumbers = imageNumbers_;
 }
 
 Block::Block(const Header& h)
-  : header(h),
-    data(new uint16_t[h.frameWidth * h.frameHeight * h.imagesInBlock],
-         std::default_delete<uint16_t[]>())
+  : header(h), data(new uint16_t[h.frameDimensions.first *
+                                 h.frameDimensions.second * h.imagesInBlock],
+                    std::default_delete<uint16_t[]>())
 {}
 
 StreamReader::StreamReader(const vector<string>& files, uint8_t version)
@@ -130,8 +125,8 @@ Header StreamReader::readHeaderVersion1() {
 
   int index = 0;
   header.imagesInBlock = headerData[index++];
-  header.frameHeight = headerData[index++];
-  header.frameWidth = headerData[index++];
+  header.frameDimensions.second = headerData[index++];
+  header.frameDimensions.first = headerData[index++];
   header.version = headerData[index++];
   header.timestamp =  headerData[index++];
   // Skip over 6 - 10 - reserved
@@ -165,8 +160,7 @@ Header StreamReader::readHeaderVersion2() {
   firstImageNumber = 0;
 
   header.imagesInBlock = 1600;
-  header.frameWidth = FRAME_WIDTH;
-  header.frameHeight = FRAME_HEIGHT;
+  header.frameDimensions = FRAME_DIMENSIONS;
   header.version = 2;
 
   // Now generate the image numbers
@@ -192,8 +186,7 @@ Header StreamReader::readHeaderVersion3()
   Header header;
 
   header.imagesInBlock = 1;
-  header.frameWidth = FRAME_WIDTH;
-  header.frameHeight = FRAME_HEIGHT;
+  header.frameDimensions = FRAME_DIMENSIONS;
   header.version = 3;
 
   // Read scan and frame number
@@ -210,13 +203,14 @@ Header StreamReader::readHeaderVersion3()
   read(headerPositions, 4 * sizeof(uint16_t));
 
   // Note: The order is currently reversed y then x rather than the other way around
-  header.scanHeight = headerPositions[index++];
-  header.scanWidth = headerPositions[index++];
+  header.scanDimensions.second = headerPositions[index++];
+  header.scanDimensions.first = headerPositions[index++];
 
   // Now get the image numbers
   auto scanYPosition = headerPositions[index++];
   auto scanXPosition = headerPositions[index++];
-  header.imageNumbers.push_back(scanYPosition * header.scanWidth  + scanXPosition);
+  header.imageNumbers.push_back(scanYPosition * header.scanDimensions.first +
+                                scanXPosition);
 
   return header;
 }
@@ -257,8 +251,8 @@ Block StreamReader::read()
 
     Block b(header);
 
-    auto dataSize =
-      b.header.frameWidth * b.header.frameHeight * b.header.imagesInBlock;
+    auto dataSize = b.header.frameDimensions.first *
+                    b.header.frameDimensions.second * b.header.imagesInBlock;
     read(b.data.get(), dataSize * sizeof(uint16_t));
 
     return b;
@@ -323,8 +317,7 @@ Header SectorStreamReader::readHeader(std::ifstream& stream)
   Header header;
 
   header.imagesInBlock = 1;
-  header.frameWidth = SECTOR_WIDTH;
-  header.frameHeight = SECTOR_HEIGHT;
+  header.frameDimensions = SECTOR_DIMENSIONS;
   header.version = 4;
 
   // Read scan and frame number
@@ -340,14 +333,14 @@ Header SectorStreamReader::readHeader(std::ifstream& stream)
   index = 0;
   read(stream, headerPositions, 4 * sizeof(uint16_t));
 
-  header.scanHeight = headerPositions[index++];
-  header.scanWidth = headerPositions[index++];
+  header.scanDimensions.second = headerPositions[index++];
+  header.scanDimensions.first = headerPositions[index++];
 
   // Now get the image numbers
   auto scanYPosition = headerPositions[index++];
   auto scanXPosition = headerPositions[index++];
 
-  header.imageNumbers.push_back(scanYPosition * header.scanWidth +
+  header.imageNumbers.push_back(scanYPosition * header.scanDimensions.first +
                                 scanXPosition);
 
   return header;
@@ -426,25 +419,26 @@ Block SectorStreamReader::read()
         if (frame.block.header.version == 0) {
           frame.block.header.version = 4;
           frame.block.header.scanNumber = header.scanNumber;
-          frame.block.header.scanWidth = header.scanWidth;
-          frame.block.header.scanHeight = header.scanHeight;
+          frame.block.header.scanDimensions = header.scanDimensions;
           frame.block.header.imagesInBlock = 1;
           frame.block.header.imageNumbers.push_back(pos);
-          frame.block.header.frameWidth = FRAME_WIDTH;
-          frame.block.header.frameHeight = FRAME_HEIGHT;
-          frame.block.data.reset(new uint16_t[frame.block.header.frameWidth *
-                                              frame.block.header.frameHeight],
-                                 std::default_delete<uint16_t[]>());
-          std::fill(
-            frame.block.data.get(),
-            frame.block.data.get() + frame.block.header.frameWidth * frame.block.header.frameHeight, 0);
+          frame.block.header.frameDimensions = FRAME_DIMENSIONS;
+          frame.block.data.reset(
+            new uint16_t[frame.block.header.frameDimensions.first *
+                         frame.block.header.frameDimensions.second],
+            std::default_delete<uint16_t[]>());
+          std::fill(frame.block.data.get(),
+                    frame.block.data.get() +
+                      frame.block.header.frameDimensions.first *
+                        frame.block.header.frameDimensions.second,
+                    0);
         }
 
-        auto frameX = sector * SECTOR_WIDTH;
-        for (unsigned frameY = 0; frameY < FRAME_HEIGHT; frameY++) {
-          auto offset = FRAME_WIDTH * frameY + frameX;
+        auto frameX = sector * SECTOR_DIMENSIONS.first;
+        for (unsigned frameY = 0; frameY < FRAME_DIMENSIONS.second; frameY++) {
+          auto offset = FRAME_DIMENSIONS.first * frameY + frameX;
           read(frame.block.data.get() + offset,
-               SECTOR_WIDTH * sizeof(uint16_t));
+               SECTOR_DIMENSIONS.first * sizeof(uint16_t));
         }
         frame.sectorCount++;
 
@@ -533,15 +527,15 @@ void SectorStreamReader::readAll(Functor func)
       }
       auto header = readHeader(stream);
       auto skip = [&stream, &header]() {
-        auto dataSize =
-          header.frameWidth * header.frameHeight * header.imagesInBlock;
+        auto dataSize = header.frameDimensions.first *
+                        header.frameDimensions.second * header.imagesInBlock;
         stream.seekg(dataSize * sizeof(uint16_t), stream.cur);
       };
 
       auto block = [&stream, &header]() -> Block {
         Block b(header);
-        auto dataSize =
-          header.frameWidth * header.frameHeight * header.imagesInBlock;
+        auto dataSize = header.frameDimensions.first *
+                        header.frameDimensions.second * header.imagesInBlock;
         stream.read(reinterpret_cast<char*>(b.data.get()),
                     dataSize * sizeof(uint16_t));
 
@@ -556,22 +550,21 @@ void SectorStreamReader::readAll(Functor func)
 float SectorStreamReader::dataCaptured()
 {
   uint64_t numberOfSectors = 0;
-  uint32_t scanWidth;
-  uint32_t scanHeight;
+  Dimensions2D scanDimensions;
 
-  auto func = [&numberOfSectors, &scanWidth, &scanHeight](
-                int sector, Header& header, auto& skip, auto& block) {
+  auto func = [&numberOfSectors, &scanDimensions](int sector, Header& header,
+                                                  auto& skip, auto& block) {
     (void)block;
     (void)sector;
     numberOfSectors++;
-    scanWidth = header.scanWidth;
-    scanHeight = header.scanHeight;
+    scanDimensions = header.scanDimensions;
     skip();
   };
 
   readAll(func);
 
-  auto expectedNumberOfSectors = scanWidth * scanHeight * 4;
+  auto expectedNumberOfSectors =
+    scanDimensions.first * scanDimensions.second * 4;
 
   return static_cast<float>(numberOfSectors) / expectedNumberOfSectors;
 }
@@ -584,12 +577,22 @@ void SectorStreamReader::toHdf5FrameFormat(h5::H5ReadWrite& writer)
 
     // When we receive the first header we can create the file
     if (!created) {
-      std::vector<int> dims = { b.header.scanWidth * b.header.scanHeight,
-                                FRAME_WIDTH, FRAME_WIDTH };
-      std::vector<int> chunkDims = { 1, FRAME_WIDTH, FRAME_HEIGHT };
+      std::vector<int> dims = {
+        static_cast<int>(b.header.scanDimensions.first) *
+          static_cast<int>(b.header.scanDimensions.second),
+        static_cast<int>(FRAME_DIMENSIONS.first),
+        static_cast<int>(FRAME_DIMENSIONS.first)
+      };
+      std::vector<int> chunkDims = {
+        1, static_cast<int>(FRAME_DIMENSIONS.first),
+        static_cast<int>(FRAME_DIMENSIONS.second)
+      };
       writer.createDataSet("/", "frames", dims,
                            h5::H5ReadWrite::DataType::UInt16, chunkDims);
-      std::vector<int> scanSize = { 0, b.header.scanHeight, b.header.scanWidth };
+      std::vector<int> scanSize = {
+        0, static_cast<int>(b.header.scanDimensions.second),
+        static_cast<int>(b.header.scanDimensions.first)
+      };
       writer.createGroup("/stem");
       writer.createDataSet("/stem", "images", scanSize,
                            h5::H5ReadWrite::DataType::UInt64);
@@ -597,10 +600,11 @@ void SectorStreamReader::toHdf5FrameFormat(h5::H5ReadWrite& writer)
     }
 
     size_t start[3] = { 0, 0, 0 };
-    size_t counts[3] = { 1, b.header.frameHeight, b.header.frameWidth };
+    size_t counts[3] = { 1, b.header.frameDimensions.second,
+                         b.header.frameDimensions.first };
     for (unsigned i = 0; i < b.header.imagesInBlock; i++) {
       auto pos = b.header.imageNumbers[0];
-      auto offset = i * FRAME_WIDTH * FRAME_HEIGHT;
+      auto offset = i * FRAME_DIMENSIONS.first * FRAME_DIMENSIONS.second;
       start[0] = pos;
 
       auto data = b.data.get() + offset;
@@ -620,21 +624,28 @@ void SectorStreamReader::toHdf5DataCubeFormat(h5::H5ReadWrite& writer)
 
     // When we receive the first header we can create the file
     if (!created) {
-      std::vector<int> dims = { b.header.scanWidth, b.header.scanHeight,
-                                FRAME_WIDTH, FRAME_WIDTH };
-      std::vector<int> chunkDims = { 1, 1, FRAME_WIDTH, FRAME_HEIGHT };
+      std::vector<int> dims = { static_cast<int>(b.header.scanDimensions.first),
+                                static_cast<int>(
+                                  b.header.scanDimensions.second),
+                                static_cast<int>(FRAME_DIMENSIONS.first),
+                                static_cast<int>(FRAME_DIMENSIONS.first) };
+      std::vector<int> chunkDims = {
+        1, 1, static_cast<int>(FRAME_DIMENSIONS.first),
+        static_cast<int>(FRAME_DIMENSIONS.second)
+      };
       writer.createDataSet("/", "datacube", dims,
                            h5::H5ReadWrite::DataType::UInt16, chunkDims);
       created = true;
     }
 
     size_t start[4] = { 0, 0, 0, 0 };
-    size_t counts[4] = { 1, 1, b.header.frameHeight, b.header.frameWidth };
+    size_t counts[4] = { 1, 1, b.header.frameDimensions.second,
+                         b.header.frameDimensions.first };
     for (unsigned i = 0; i < b.header.imagesInBlock; i++) {
       auto pos = b.header.imageNumbers[0];
-      auto offset = i * FRAME_WIDTH * FRAME_HEIGHT;
-      auto x = pos % b.header.scanWidth;
-      auto y = pos / b.header.scanWidth;
+      auto offset = i * FRAME_DIMENSIONS.first * FRAME_DIMENSIONS.second;
+      auto x = pos % b.header.scanDimensions.first;
+      auto y = pos / b.header.scanDimensions.first;
       start[0] = x;
       start[1] = y;
 

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -14,7 +14,10 @@ class H5ReadWrite;
 
 namespace stempy {
 
+// Convention is (x, y)
 using Coordinates2D = std::pair<int, int>;
+
+// Convention is (width, height)
 using Dimensions2D = std::pair<uint32_t, uint32_t>;
 
 struct EofException : public std::exception

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace h5 {
@@ -13,25 +14,27 @@ class H5ReadWrite;
 
 namespace stempy {
 
+using Coordinates2D = std::pair<int, int>;
+using Dimensions2D = std::pair<uint32_t, uint32_t>;
+
 struct EofException : public std::exception
 {
   const char* what () const throw () { return "EOF Exception"; }
 };
 
 struct Header {
-  uint32_t imagesInBlock = 0, frameHeight = 0, frameWidth = 0, version = 0,
-           timestamp = 0;
+  Dimensions2D scanDimensions = { 0, 0 };
+  Dimensions2D frameDimensions = { 0, 0 };
+  uint32_t imagesInBlock = 0, version = 0, timestamp = 0;
   uint32_t frameNumber = 0, scanNumber = 0;
-  uint16_t scanHeight = 0, scanWidth = 0;
   std::vector<uint32_t> imageNumbers;
 
   Header() = default;
   Header(const Header& header) = default;
   Header(Header&& header) noexcept = default;
   Header& operator=(Header&& header) noexcept = default;
-  Header(uint32_t frameWidth, uint32_t frameHeight, uint32_t imageNumInBlock,
-         uint32_t scanWidth, uint32_t scanHeight,
-         std::vector<uint32_t>& imageNumbers);
+  Header(Dimensions2D frameDimensions, uint32_t imageNumInBlock,
+         Dimensions2D scanDimensions, std::vector<uint32_t>& imageNumbers);
 };
 
 struct Block {


### PR DESCRIPTION
Rather than having separate variables for things such as width and
height, combine them into one variable. In python, this is a tuple, and
in C++, this is a std::pair.

This combines scan width and scan height into "scan_dimensions" (python)
and "scanDimensions" (C++) variables. Frame width and frame height are
combined into "frame_dimensions" (python) and "frameDimensions" (C++).

Center x and Center y are combined into just a "center" variable.

Typically, dimensions.first is the width, and dimensions.second is the
height. But there is one place where the ordering was switched, because
it appeared to be wrong: maximalPointsParallel in electron.cpp. This
needs to be tested with a non-square dataset.

Fixes: #54
Fixes: #106
Fixes: #107
Fixes: #108