### PR TITLE
Avoid copying data for PyReader's PyBlock

### DIFF
--- a/python/io.cpp
+++ b/python/io.cpp
@@ -25,7 +25,10 @@ PYBIND11_MODULE(_io, m)
     .def_readonly("header", &Block::header)
     .def_buffer([](Block& b) {
       return py::buffer_info(
-        b.data.get(),     /* Pointer to buffer */
+        // const_cast is needed because the buffer_info constructor
+        // requires a non-const pointer. pybind11 also internally uses
+        // const_cast to achieve the same purpose.
+        const_cast<uint16_t*>(b.data.get()),       /* Pointer to buffer */
         sizeof(uint16_t), /* Size of one scalar */
         py::format_descriptor<
           uint16_t>::format(), /* Python struct-style format descriptor */
@@ -33,16 +36,19 @@ PYBIND11_MODULE(_io, m)
         { b.header.imagesInBlock, b.header.frameHeight,
           b.header.frameWidth }, /* Buffer dimensions */
         { sizeof(uint16_t) * b.header.frameHeight * b.header.frameWidth,
-          sizeof(uint16_t) *
-            b.header.frameHeight, /* Strides (in bytes) for each index */
-          sizeof(uint16_t) });
+          sizeof(uint16_t) * b.header.frameHeight,
+          sizeof(uint16_t) } /* Strides (in bytes) for each index */
+      );
     });
 
   py::class_<PyBlock>(m, "_pyblock", py::buffer_protocol())
     .def_readonly("header", &PyBlock::header)
     .def_buffer([](PyBlock& b) {
       return py::buffer_info(
-        b.data.get(),     /* Pointer to buffer */
+        // const_cast is needed because the buffer_info constructor
+        // requires a non-const pointer. pybind11 also internally uses
+        // const_cast to achieve the same purpose.
+        const_cast<uint16_t*>(b.data.get()),       /* Pointer to buffer */
         sizeof(uint16_t), /* Size of one scalar */
         py::format_descriptor<
           uint16_t>::format(), /* Python struct-style format descriptor */
@@ -50,9 +56,9 @@ PYBIND11_MODULE(_io, m)
         { b.header.imagesInBlock, b.header.frameHeight,
           b.header.frameWidth }, /* Buffer dimensions */
         { sizeof(uint16_t) * b.header.frameHeight * b.header.frameWidth,
-          sizeof(uint16_t) *
-            b.header.frameHeight, /* Strides (in bytes) for each index */
-          sizeof(uint16_t) });
+          sizeof(uint16_t) * b.header.frameHeight,
+          sizeof(uint16_t) } /* Strides (in bytes) for each index */
+      );
     });
 
   py::class_<StreamReader::iterator>(m, "_reader_iterator")

--- a/python/pyreader.cpp
+++ b/python/pyreader.cpp
@@ -5,12 +5,9 @@ namespace stempy {
 
 PyBlock::PyBlock(py::array_t<uint16_t> pyarray)
 {
-  // For now just copy the memory, we should be able to use inplace, but we are
-  // seeing a double delete.
-  this->data.reset(new uint16_t[pyarray.size()],
-                   std::default_delete<uint16_t[]>());
-  std::memcpy(this->data.get(), pyarray.data(),
-              pyarray.size() * sizeof(u_int16_t));
+  // Since this is the constructor, this should not be deleting anything
+  // Otherwise, we might would need py::gil_scoped_acquire gil
+  this->data.array.reset(new py::array_t<uint16_t>(std::move(pyarray)));
 }
 
 PyReader::PyReader(py::object pyDataSet, std::vector<uint32_t>& imageNumbers,

--- a/python/pyreader.h
+++ b/python/pyreader.h
@@ -11,20 +11,32 @@ namespace py = pybind11;
 
 namespace stempy {
 
-struct DataHolder
+struct PYBIND11_EXPORT DataHolder
 {
   DataHolder() = default;
-  const uint16_t* innerdata = nullptr;
-  const uint16_t* get() { return innerdata; }
-  void reset() { return; }
+
+  const uint16_t* get()
+  {
+    if (!this->array) {
+      return nullptr;
+    }
+
+    return this->array->data();
+  }
+
+  void reset()
+  {
+    py::gil_scoped_acquire gil;
+    this->array.reset();
+  }
+
+  std::shared_ptr<py::array_t<uint16_t>> array;
 };
 
 struct PYBIND11_EXPORT PyBlock
 {
   Header header;
-  // py::array_t<uint16_t> m_array;
-  // DataHolder data;
-  std::shared_ptr<uint16_t> data;
+  DataHolder data;
   PyBlock() = default;
   PyBlock(py::array_t<uint16_t> pyarray);
 };


### PR DESCRIPTION
The data was previously copied in order to prevent seg faults. These
changes fix the seg faults, though, by keeping a copy of the pybind11
object around so that internal PyObject's reference count doesn't go
to zero.

A wrapper is needed to store the pybind11 object so that the API for
calling it is similar to std::shared_ptr, so that it can be used
in the stempy C++ template functions. Additionally, the pybind11 object
is stored in a std::shared_ptr internally, so that the PyBlock object
can be copied without copying the data (as is done with other types of
Block objects in stempy).

const_cast is needed in io.cpp because the buffer_info constructor
requires a non-const pointer. pybind11 also internally uses const_cast
to achieve the same purpose.