### PR TITLE
Initial setup for Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==2.3.1
 pygments==2.4.2
+sphinx-rtd-theme==0.4.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
-pygments
+sphinx==2.3.1
+pygments==2.4.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,8 @@
 
 import os
 import sys
+
+import sphinx_rtd_theme
 from unittest import mock
 
 sys.path.insert(0, os.path.abspath('../../python/stempy'))
@@ -32,7 +34,7 @@ release = '1.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -62,7 +64,7 @@ _io_mock._pyreader = object
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,15 +42,14 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-# Mock out pybind11 generated modules, we do this manually as we
-# have a nested class that uses problems with sphinx's mocking.
-class MockReader(object):
-    class H5Format(object):
+# Unfortunately, if we have a class that inherits sphinx's mock
+# object, and we use that class in a default argument, we run into
+# attribute errors. Fix it by defining an explicit mock of the class.
+class MockReader:
+    class H5Format:
         Frame = 1
 
-for mod_name in ['stempy._io', 'stempy._image']:
-    sys.modules[mod_name] = mock.Mock()
-
+sys.modules['stempy._io'] = mock.Mock()
 _io_mock = sys.modules['stempy._io']
 
 # We have to override these so we get don't get conflicting metaclasses
@@ -70,6 +69,13 @@ html_theme = 'alabaster'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Get autodoc to mock these imports, because we don't actually need them
+# for generating the docs
+autodoc_mock_imports = [
+    'stempy._image',
+    'numpy',
+    'h5py'
+]
 
 # Modify this function to customize which classes/functions are skipped
 def autodoc_skip_member_handler(app, what, name, obj, skip, options):

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,8 @@
+stempy
+======
+
+.. toctree::
+   :maxdepth: 4
+
+   stempy.image
+   stempy.io

--- a/docs/source/stempy.image.rst
+++ b/docs/source/stempy.image.rst
@@ -1,0 +1,10 @@
+stempy.image package
+====================
+
+Module contents
+---------------
+
+.. automodule:: stempy.image
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/stempy.io.rst
+++ b/docs/source/stempy.io.rst
@@ -1,0 +1,10 @@
+stempy.io package
+=================
+
+Module contents
+---------------
+
+.. automodule:: stempy.io
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -72,7 +72,9 @@ def get_hdf5_reader(h5file):
 
 
 def reader(path, version=FileVersion.VERSION1):
-    """Create a file reader to read the data.
+    """reader(path, version=FileVersion.VERSION1)
+
+    Create a file reader to read the data.
 
     :param path: either the path to the file or an open h5py file.
     :type path: str or h5py file
@@ -174,7 +176,9 @@ def save_stem_images(outputFile, images, names):
         dataset.attrs['names'] = names
 
 def write_hdf5(path, reader, format=SectorReader.H5Format.Frame):
-    """Write the data from a SectorReader to an HDF5 file.
+    """write_hdf5(path, reader, format=SectorReader.H5Format.Frame)
+
+    Write the data from a SectorReader to an HDF5 file.
 
     :param path: path to the output HDF5 file.
     :type path: str


### PR DESCRIPTION
This adds a .readthedocs.yml file, and it makes some changes to
the docs code so that Read the Docs will work.

The files automatically generated by `sphinx-apidoc` were committed,
because Read the Docs does not run `sphinx-apidoc`.