### PR TITLE
Add descriptions for our named tuples

### DIFF
--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -248,7 +248,8 @@ def electron_count(reader, darkreference, number_of_samples=40,
     :type verbose: bool
 
     :return: the coordinates of the electron hits for each frame.
-    :rtype: ElectronCountedData (named tuple)
+    :rtype: ElectronCountedData (named tuple with fields 'data',
+            'scan_dimensions', and 'frame_dimensions')
     """
     blocks = []
     for i in range(threshold_num_blocks):

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -26,7 +26,7 @@ class ReaderMixin(object):
         """Read the next block of data from the file.
 
         :return: The block of data that was read. Includes the header also.
-        :rtype: Block
+        :rtype: Block (named tuple with fields 'header' and 'data')
         """
         b = super(ReaderMixin, self).read()
 


### PR DESCRIPTION
This adds descriptions for our named tuples in the return type
descriptions of the functions that return them.