### PR TITLE
Add RTD badge and singularity instructions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+[![Documentation Status](https://readthedocs.org/projects/stempy/badge/?version=latest)](https://stempy.readthedocs.io/en/latest/?badge=latest)
+
 Toolkit for processing 4D STEM image data on HPC.
+
+Singularity instructions may be found [here](https://stempy.readthedocs.io/en/latest/singularity.html).
 
 Build instructions may be found [here](BUILDING.md).
 


### PR DESCRIPTION
The singularity instructions link points to the Read the Docs page.