### PR TITLE
Fix compiler warnings

### DIFF
--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -136,7 +136,7 @@ std::vector<uint32_t> maximalPoints(const std::vector<uint16_t>& frame,
 
   std::vector<uint32_t> events;
   auto numberOfPixels = height * width;
-  for (int i = 0; i < numberOfPixels; i++) {
+  for (uint32_t i = 0; i < numberOfPixels; ++i) {
     auto row = i / width;
     auto column = i % width;
     auto rightNeighbourColumn = mod((i + 1), width);

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -113,7 +113,7 @@ CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
   // Now generate a histograms
   auto minMax = std::minmax_element(samples.begin(), samples.end());
   auto minSample = *minMax.first;
-  auto maxSample = std::ceil(*minMax.second);
+  auto maxSample = static_cast<int16_t>(std::ceil(*minMax.second));
   auto maxBin = std::min(static_cast<int>(maxSample),
                          static_cast<int>(mean + xrayThreshold * stdDev));
   auto minBin = std::max(static_cast<int>(minSample),

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -322,7 +322,7 @@ std::vector<int> createSTEMHistogram(const STEMImage& inImage,
   auto curData = inImage.data;
 
   // get a histrogram
-  for (int i = 0; i < scanDimensions.first * scanDimensions.second; i++) {
+  for (uint32_t i = 0; i < scanDimensions.first * scanDimensions.second; ++i) {
     auto value = curData[i];
     // check which bin it belongs to
     for (int j = 0; j < numBins; j++) {
@@ -435,7 +435,7 @@ void radialSumFrame(Coordinates2D center, const uint16_t data[],
                     int imageNumber, RadialSum<uint64_t>& radialSum)
 {
   auto numberOfPixels = frameDimensions.first * frameDimensions.second;
-  for (int i=0; i< numberOfPixels; i++) {
+  for (uint32_t i = 0; i < numberOfPixels; ++i) {
     auto x = i % frameDimensions.first;
     auto y = i / frameDimensions.first;
     auto radius =

--- a/stempy/mask.cpp
+++ b/stempy/mask.cpp
@@ -13,15 +13,15 @@ uint16_t* createAnnularMask(Dimensions2D dimensions, int innerRadius,
   auto mask = new uint16_t[numberOfElements]();
 
   if (center.first < 0)
-    center.first = round(dimensions.first / 2.0);
+    center.first = static_cast<int>(round(dimensions.first / 2.0));
 
   if (center.second < 0)
-    center.second = round(dimensions.second / 2.0);
+    center.second = static_cast<int>(round(dimensions.second / 2.0));
 
   innerRadius = static_cast<int>(pow(innerRadius, 2.0));
   outerRadius = static_cast<int>(pow(outerRadius, 2.0));
 
-  for (int i=0; i<numberOfElements; i++) {
+  for (uint32_t i = 0; i < numberOfElements; ++i) {
     // Ensure these are signed ints so we don't underflow below
     int x = i % dimensions.first;
     int y = i / dimensions.first;


### PR DESCRIPTION
This fixes compiler warnings that are caused by some automatic type
conversions and comparisons between signed and unsigned integers.