### PR TITLE
Overload create stem image functions

### DIFF
--- a/examples/electron.ipynb
+++ b/examples/electron.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "inner_radius = 40\n",
     "outer_radius = 288\n",
-    "stem_img = image.create_stem_image_sparse(electron_counted_data, inner_radius, outer_radius)"
+    "stem_img = image.create_stem_images(electron_counted_data, inner_radius, outer_radius)[0]"
    ]
   },
   {

--- a/examples/electron_mpi.py
+++ b/examples/electron_mpi.py
@@ -17,8 +17,7 @@ def get_files(files):
 @click.command()
 @click.argument('files', nargs=-1,
                 type=click.Path(exists=True, dir_okay=False))
-@click.option('-d', '--dark-file', help='The file for dark field reference',
-              required=True)
+@click.option('-d', '--dark-file', help='The file for dark field reference')
 @click.option('-c', '--center', help='The center (comma separated)',
               required=True)
 @click.option('-i', '--inner-radii', help='The inner radii (comma separated)',
@@ -61,9 +60,12 @@ def main(files, dark_file, center, inner_radii, outer_radii, output_file,
     comm.Barrier()
     start = MPI.Wtime()
 
-    # Every process will do the dark field reference average for now
-    reader = io.reader(dark_file, version=io.FileVersion.VERSION3)
-    dark = image.calculate_average(reader)
+    if dark_file is not None:
+        # Every process will do the dark field reference average for now
+        reader = io.reader(dark_file, version=io.FileVersion.VERSION3)
+        dark = image.calculate_average(reader)
+    else:
+        dark = np.zeros((576, 576))
 
     # Split up the files among processes
     files = get_files(files)
@@ -94,7 +96,7 @@ def main(files, dark_file, center, inner_radii, outer_radii, output_file,
         if generate_sparse:
             # Save out the sparse image
 
-            stem_imgs = image.create_stem_images_sparse(
+            stem_imgs = image.create_stem_images(
                 global_frame_events, inner_radii, outer_radii,
                 scan_dimensions=scan_dimensions,
                 frame_dimensions=frame_dimensions, center=center)

--- a/examples/electron_stem_image.py
+++ b/examples/electron_stem_image.py
@@ -27,7 +27,8 @@ num_pixels = frame_dimensions[0] * frame_dimensions[1]
 inner_radius = 40
 outer_radius = 288
 
-img = image.create_stem_image_sparse(frames, inner_radius, outer_radius,
-                                     scan_dimensions, frame_dimensions)
+img = image.create_stem_images(frames, inner_radius, outer_radius,
+                               scan_dimensions,
+                               frame_dimensions=frame_dimensions)[0]
 
 save_img(img, 'img.png', scan_dimensions)

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -141,16 +141,16 @@ PYBIND11_MODULE(_image, m)
         py::call_guard<py::gil_scoped_release>());
   m.def("create_stem_images", &createSTEMImages<SectorStreamReader::iterator>,
         py::call_guard<py::gil_scoped_release>());
-  m.def("create_stem_images_sparse",
+  m.def("create_stem_images",
         (vector<STEMImage>(*)(const vector<vector<uint32_t>>&,
                               const vector<int>&, const vector<int>&,
                               Dimensions2D, Dimensions2D, Coordinates2D, int)) &
-          createSTEMImagesSparse,
+          createSTEMImages,
         py::call_guard<py::gil_scoped_release>());
-  m.def("create_stem_images_sparse",
+  m.def("create_stem_images",
         (vector<STEMImage>(*)(const ElectronCountedData&, const vector<int>&,
                               const vector<int>&, Coordinates2D)) &
-          createSTEMImagesSparse,
+          createSTEMImages,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_average", &calculateAverage<StreamReader::iterator>,
         py::call_guard<py::gil_scoped_release>());

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     package_dir={'':'python'},
     install_requires=[
         'numpy',
-        'h5py'
+        'h5py',
+        'deprecation'
     ]
 )

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -352,7 +352,7 @@ void calculateSTEMValuesSparse(const vector<vector<uint32_t>>& data,
   }
 }
 
-vector<STEMImage> createSTEMImagesSparse(
+vector<STEMImage> createSTEMImages(
   const vector<vector<uint32_t>>& sparseData, const vector<int>& innerRadii,
   const vector<int>& outerRadii, Dimensions2D scanDimensions,
   Dimensions2D frameDimensions, Coordinates2D center, int frameOffset)
@@ -386,14 +386,14 @@ vector<STEMImage> createSTEMImagesSparse(
   return images;
 }
 
-vector<STEMImage> createSTEMImagesSparse(const ElectronCountedData& data,
-                                         const vector<int>& innerRadii,
-                                         const vector<int>& outerRadii,
-                                         Coordinates2D center)
+vector<STEMImage> createSTEMImages(const ElectronCountedData& data,
+                                   const vector<int>& innerRadii,
+                                   const vector<int>& outerRadii,
+                                   Coordinates2D center)
 {
-  return createSTEMImagesSparse(data.data, innerRadii, outerRadii,
-                                data.scanDimensions, data.frameDimensions,
-                                center);
+  return createSTEMImages(data.data, innerRadii, outerRadii,
+                          data.scanDimensions, data.frameDimensions,
+                          center);
 }
 
 template <typename InputIt>

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -39,21 +39,24 @@ namespace stempy {
 
   using STEMImage = Image<uint64_t>;
 
+  // Create STEM Images from raw data
   template <typename InputIt>
   std::vector<STEMImage> createSTEMImages(
     InputIt first, InputIt last, const std::vector<int>& innerRadii,
     const std::vector<int>& outerRadii, Dimensions2D scanDimensions = { 0, 0 },
     Coordinates2D center = { -1, -1 });
 
-  std::vector<STEMImage> createSTEMImagesSparse(
+  // Create STEM Images from sparse data
+  std::vector<STEMImage> createSTEMImages(
     const std::vector<std::vector<uint32_t>>& sparseData,
     const std::vector<int>& innerRadii, const std::vector<int>& outerRadii,
     Dimensions2D scanDimensions = { 0, 0 },
     Dimensions2D frameDimensions = { 0, 0 }, Coordinates2D center = { -1, -1 },
     int frameOffset = 0);
 
+  // Create STEM Images from electron counted sparse data
   struct ElectronCountedData;
-  std::vector<STEMImage> createSTEMImagesSparse(
+  std::vector<STEMImage> createSTEMImages(
     const ElectronCountedData& sparseData, const std::vector<int>& innerRadii,
     const std::vector<int>& outerRadii, Coordinates2D center = { -1, -1 });
 


### PR DESCRIPTION
Rather than having separate functions for sparse STEM image creation
such as "create_stem_image_sparse", combine all of the sparse STEM
image functions (and the singular "create_stem_image" function) into
"create_stem_images".

"create_stem_images" determines the type of its input, and calls the
correct function signature based upon it. Now, a user can pass to
"create_stem_images" one of four options:

1. A stempy.io.reader
2. An open h5py file
3. ElectronCountedData (returned from electron counting) sparse data
4. A numpy array of sparse data

The "create_stem_images" function handles all of these inputs.

Additionally, on the C++ side, the "...Sparse()" functions were renamed
to overload "createSTEMImages".

This reduces the number of function names that we have to work with,
and it allows the code to automatically determine which functions to
call based upon the input.

This also adds and uses a deprecation package which automatically
generates deprecation information in the sphinx documentation for
deprecated functions.

Fixes: #84