### PR TITLE
Sort frame data when writing to an HDF5 file

### DIFF
--- a/examples/create_hdf5.py
+++ b/examples/create_hdf5.py
@@ -80,8 +80,8 @@ def make_stem_hdf5(files, dark_sample, width, height, inner_radius,
 
         # In order to avoid two copies of the data, we must allocate
         # space for the large numpy array first.
-        raw_data = np.zeros((np.prod(scan_dimensions), frame_dimensions[0],
-                            frame_dimensions[1]), dtype=np.uint16)
+        raw_data = np.zeros((np.prod(scan_dimensions), frame_dimensions[1],
+                            frame_dimensions[0]), dtype=np.uint16)
 
         # Make sure the frames are sorted in order
         for block in reader:

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -95,13 +95,16 @@ def reader(path, version=FileVersion.VERSION1):
 
     return reader
 
-def save_raw_data(path, data, zip_data=False):
+def save_raw_data(path, data, scan_positions=None, zip_data=False):
     """Save the raw data to an HDF5 file.
 
     :param path: path to the HDF5 file.
     :type path: str
     :param data: the raw data to save.
     :type data: numpy.ndarray
+    :param scan_positions: the scan positions of each frame. This is
+                           only needed if the frames are not sorted.
+    :type scan_positions: list of ints
     :param zip_data: whether or not to compress the data with gzip.
     :type zip_data: bool
     """
@@ -122,6 +125,9 @@ def save_raw_data(path, data, zip_data=False):
                              chunks=chunk_shape)
         else:
             f.create_dataset('frames', data=data)
+
+        if scan_positions is not None:
+            f.create_dataset('scan_positions', data=scan_positions)
 
 def save_electron_counts(path, events, scan_dimensions, frame_dimensions=None):
     """Save the electron counted data to an HDF5 file.

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -602,7 +602,7 @@ void SectorStreamReader::toHdf5FrameFormat(h5::H5ReadWrite& writer)
     size_t counts[3] = { 1, b.header.frameDimensions.second,
                          b.header.frameDimensions.first };
     for (unsigned i = 0; i < b.header.imagesInBlock; i++) {
-      auto pos = b.header.imageNumbers[0];
+      auto pos = b.header.imageNumbers[i];
       auto offset = i * FRAME_DIMENSIONS.first * FRAME_DIMENSIONS.second;
       start[0] = pos;
 


### PR DESCRIPTION
In order for a reader of the HDF5 stempy file to know the
scan positions, one of two things needs to be true:
    
1. The frame images need to be sorted numerically, starting with 0
2. The "scan_positions" need to be written to a data set
    
This fixes the "create_hdf5.py" file so that the frame images are
sorted numerically (additionally, these changes also remove the need
to have two copies of the data in memory, which was a problem with
"create_hdf5.py" before).
    
This PR also adds an option to write the scan positions in
stempy.io.save_raw_data(), in case that is preferable to callers.

Fixes: #111