### PR TITLE
Save the scan dimensions to /frames

### DIFF
--- a/docs/source/StempyH5Format.rst
+++ b/docs/source/StempyH5Format.rst
@@ -17,7 +17,7 @@ Currently, the structure of the format is as follows:
    frames
 
 
-* 
+*
   ``electron_events/frames`` - Array of arrays, the first index is the scan position
   ( corresponding to ``scan_positions`` ) and the second array holds an array of
   of indices into the diffractogram where an electron strike was detected.
@@ -28,7 +28,7 @@ Currently, the structure of the format is as follows:
     * ``Nx``\ : the width of the frame
     * ``Ny``\ : the height of the frame
 
-* 
+*
   ``electron_events/scan_positions`` - Array of shorts holding the scan positions.
 
 
@@ -37,7 +37,7 @@ Currently, the structure of the format is as follows:
     * ``Nx``\ : the width of the scan
     * ``Ny``\ : the height of the scan
 
-* 
+*
   ``stem/images`` - A list of 2D arrays of unsigned integers containing stem images
   (possibly bright and dark fields).
 
@@ -46,9 +46,14 @@ Currently, the structure of the format is as follows:
 
     * ``names``\ : a list of names assigned to the images
 
-* 
+*
   ``frames`` - If present, the raw diffractogram data, where the first index is the scan
   position index for the 2D diffractogram.
+
+
+  * Attributes:
+
+    * ``scan_dimensions``\ : the dimensions (width, height) of the scan
 
 This file can be produced with the script at ``examples/create_hdf5.py``
 by using a command similar to the following:

--- a/h5cpp/h5readwrite.h
+++ b/h5cpp/h5readwrite.h
@@ -287,6 +287,17 @@ public:
   bool setAttribute(const std::string& path, const std::string& name, T value);
 
   /**
+   * Set an attribute on a specified path.
+   * @param path The path where the attribute will be written.
+   * @param name The name of the attribute.
+   * @param values The values of the attribute.
+   * @return True on success, false on failure.
+   */
+  template <typename T>
+  bool setAttribute(const std::string& path, const std::string& name,
+                    const std::vector<T>& values);
+
+  /**
    * Create a group.
    * @param path The path to the group that will be created.
    * @return True on success, false on failure

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -71,9 +71,14 @@ def get_hdf5_reader(h5file):
     dset_frame=h5file['frames']
     dset_frame_shape=dset_frame.shape
     totalImgNum=dset_frame_shape[0]
-
-    dset_stem_shape=h5file['stem/images'].shape
-    scan_dimensions = (dset_stem_shape[2], dset_stem_shape[1])
+    scan_dimensions = dset_frame.attrs.get('scan_dimensions')
+    if scan_dimensions is None:
+        # Must be an older file. Give a warning and fall back to the shape.
+        print('WARNING: "scan_dimensions" not found on "/frames"',
+              '(which may imply an older file is being loaded).',
+              'Falling back to the shape of "stem/images"')
+        dset_stem_shape = h5file['stem/images'].shape
+        scan_dimensions = (dset_stem_shape[2], dset_stem_shape[1])
 
     blocksize=32
     # construct the consecutive image_numbers if there is no scan_positions data set in hdf5 file
@@ -121,13 +126,17 @@ def reader(path, version=FileVersion.VERSION1, backend=None, **options):
 
     return reader
 
-def save_raw_data(path, data, scan_positions=None, zip_data=False):
+def save_raw_data(path, data, scan_dimensions=None, scan_positions=None,
+                  zip_data=False):
     """Save the raw data to an HDF5 file.
 
     :param path: path to the HDF5 file.
     :type path: str
     :param data: the raw data to save.
     :type data: numpy.ndarray
+    :param scan_dimensions: the dimensions of the scan, where the order is
+                            (width, height).
+    :type scan_dimensions: tuple of ints of length 2
     :param scan_positions: the scan positions of each frame. This is
                            only needed if the frames are not sorted.
     :type scan_positions: list of ints
@@ -147,10 +156,13 @@ def save_raw_data(path, data, scan_positions=None, zip_data=False):
         if zip_data:
             # Make each chunk the size of a frame
             chunk_shape = (1, data.shape[1], data.shape[2])
-            f.create_dataset('frames', data=data, compression='gzip',
-                             chunks=chunk_shape)
+            frames = f.create_dataset('frames', data=data, compression='gzip',
+                                      chunks=chunk_shape)
         else:
-            f.create_dataset('frames', data=data)
+            frames = f.create_dataset('frames', data=data)
+
+        if scan_dimensions is not None:
+            frames.attrs['scan_dimensions'] = scan_dimensions
 
         if scan_positions is not None:
             f.create_dataset('scan_positions', data=scan_positions)

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -653,6 +653,12 @@ void SectorStreamReader::toHdf5FrameFormat(h5::H5ReadWrite& writer)
       };
       writer.createDataSet("/", "frames", dims,
                            h5::H5ReadWrite::DataType::UInt16, chunkDims);
+      std::vector<int> scanDimensions = {
+        static_cast<int>(b.header.scanDimensions.first),
+        static_cast<int>(b.header.scanDimensions.second)
+      };
+      writer.setAttribute("/frames", "scan_dimensions", scanDimensions);
+
       std::vector<int> scanSize = {
         0, static_cast<int>(b.header.scanDimensions.second),
         static_cast<int>(b.header.scanDimensions.first)
@@ -660,6 +666,7 @@ void SectorStreamReader::toHdf5FrameFormat(h5::H5ReadWrite& writer)
       writer.createGroup("/stem");
       writer.createDataSet("/stem", "images", scanSize,
                            h5::H5ReadWrite::DataType::UInt64);
+
       created = true;
     }
 


### PR DESCRIPTION
In the HDF5 format, save the scan dimensions to /frames as
a list of two attributes (width, height).

This also changes the convention we currently have to save
dimension attributes as a list of two attributes (width, height)
rather than as separate attributes, such as Nx and Ny.

This is not fully tested and may not fully work.

Fixes: #126