### PR TITLE
Allow radii to be tuples in create_stem_images()

### DIFF
--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -46,10 +46,10 @@ def create_stem_images(input, inner_radii, outer_radii, scan_dimensions=(0, 0),
     :return: A numpy array of the STEM images.
     :rtype: numpy.ndarray
     """
-    # Ensure the inner and outer radii are lists
-    if not isinstance(inner_radii, list):
+    # Ensure the inner and outer radii are tuples or lists
+    if not isinstance(inner_radii, (tuple, list)):
         inner_radii = [inner_radii]
-    if not isinstance(outer_radii, list):
+    if not isinstance(outer_radii, (tuple, list)):
         outer_radii = [outer_radii]
 
     if isinstance(input, h5py._hl.files.File):


### PR DESCRIPTION
The previous behavior would convert tuple radii into a list
of tuples, which would cause an overload resolution error.

Pybind11 can automatically convert the tuples into std::vector,
so allow them to be passed as well.

Fixes: #136 