### PR TITLE
Ensure GIL is acquired before deleting py::array

### DIFF
--- a/python/pyreader.h
+++ b/python/pyreader.h
@@ -14,6 +14,39 @@ namespace stempy {
 struct PYBIND11_EXPORT DataHolder
 {
   DataHolder() = default;
+  DataHolder(const DataHolder&) = default;
+  DataHolder(DataHolder&&) = default;
+
+  DataHolder& operator=(const DataHolder& other)
+  {
+    if (this != &other) {
+      // Need to acquire the gil before deleting the python array
+      // or there may be a crash.
+      py::gil_scoped_acquire gil;
+      this->array = other.array;
+    }
+
+    return *this;
+  }
+
+  DataHolder& operator=(DataHolder&& other)
+  {
+    if (this != &other) {
+      // Need to acquire the gil before deleting the python array
+      // or there may be a crash.
+      py::gil_scoped_acquire gil;
+      this->array = std::move(other.array);
+    }
+
+    return *this;
+  }
+
+  ~DataHolder()
+  {
+    // Need to acquire the gil before deleting the python array
+    // or there may be a crash.
+    reset();
+  }
 
   const uint16_t* get()
   {


### PR DESCRIPTION
Although the DataHolder class was acquiring the GIL before
decrementing the reference count on the shared pointer when "reset()"
was called, there were a few cases where the GIL was not acquired.
This causes a crash when the last shared pointer is destroyed.

The cases in DataHolder where the GIL was not acquired were:

1. Destructor
2. Copy assignment
3. Move assignment

Both 1 and 2 were being performed in the electron counting code.

This hopefully fixes all of the cases where the shared pointer's
reference count is decremented without the GIL being acquired.

Fixes: #138 