### PR TITLE
Read electron counted data from HDF5 file

### DIFF
--- a/examples/create_hdf5.py
+++ b/examples/create_hdf5.py
@@ -60,7 +60,6 @@ def make_stem_hdf5(files, dark_sample, width, height, inner_radius,
     reader = io.reader(files, version=reader_version)
     data = image.electron_count(reader, dark, scan_dimensions=scan_dimensions)
 
-    frame_events = data.data
     frame_dimensions = data.frame_dimensions
 
     inner_radii = [0, inner_radius]
@@ -71,8 +70,7 @@ def make_stem_hdf5(files, dark_sample, width, height, inner_radius,
     imgs = image.create_stem_images(reader, inner_radii, outer_radii,
                                     scan_dimensions=scan_dimensions)
 
-    io.save_electron_counts(output, frame_events, scan_dimensions,
-                            frame_dimensions)
+    io.save_electron_counts(output, data)
     io.save_stem_images(output, imgs, names)
 
     if save_raw:

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -66,8 +66,12 @@ def create_stem_images(input, inner_radii, outer_radii, scan_dimensions=(0, 0),
         imgs = _image.create_stem_images(input.begin(), input.end(),
                                          inner_radii, outer_radii,
                                          scan_dimensions, center)
+    elif hasattr(input, '_electron_counted_data'):
+        # Handle electron counted data with C++ object
+        imgs = _image.create_stem_images(input._electron_counted_data,
+                                         inner_radii, outer_radii, center)
     elif all([hasattr(input, x) for x in ecd_attrs]):
-        # Handle electron counted data
+        # Handle electron counted data without C++ object
         imgs = _image.create_stem_images(input.data, inner_radii, outer_radii,
                                          input.scan_dimensions,
                                          input.frame_dimensions, center, 0)

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -52,6 +52,9 @@ def create_stem_images(input, inner_radii, outer_radii, scan_dimensions=(0, 0),
     if not isinstance(outer_radii, (tuple, list)):
         outer_radii = [outer_radii]
 
+    # Electron counted data attributes
+    ecd_attrs = ['data', 'scan_dimensions', 'frame_dimensions']
+
     if isinstance(input, h5py._hl.files.File):
         # Handle h5py file
         input = get_hdf5_reader(input)
@@ -63,10 +66,11 @@ def create_stem_images(input, inner_radii, outer_radii, scan_dimensions=(0, 0),
         imgs = _image.create_stem_images(input.begin(), input.end(),
                                          inner_radii, outer_radii,
                                          scan_dimensions, center)
-    elif hasattr(input, '_electron_counted_data'):
+    elif all([hasattr(input, x) for x in ecd_attrs]):
         # Handle electron counted data
-        imgs = _image.create_stem_images(input._electron_counted_data,
-                                         inner_radii, outer_radii, center)
+        imgs = _image.create_stem_images(input.data, inner_radii, outer_radii,
+                                         input.scan_dimensions,
+                                         input.frame_dimensions, center, 0)
     elif isinstance(input, np.ndarray):
         # The presence of frame dimensions implies it is sparse data
         if frame_dimensions is not None:

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -162,6 +162,31 @@ def save_electron_counts(path, events, scan_dimensions, frame_dimensions=None):
 
         frames[...] = events
 
+def read_electron_counts(path):
+    """Read electron counted data from an HDF5 file.
+
+    :param path: path to the HDF5 file.
+    :type path: str
+
+    :return: the coordinates of the electron hits for each frame.
+    :rtype: ElectronCountedData (named tuple with fields 'data',
+            'scan_dimensions', and 'frame_dimensions')
+    """
+
+    ret = namedtuple('ElectronCountedData',
+                     ['data', 'scan_dimensions', 'frame_dimensions'])
+
+    with h5py.File(path, 'r') as f:
+        frames = f['electron_events/frames']
+        scan_positions = f['electron_events/scan_positions']
+
+        ret.data = frames[()]
+        ret.scan_dimensions = [scan_positions.attrs[x] for x in ['Nx', 'Ny']]
+        if 'Nx' in frames.attrs and 'Ny' in frames.attrs:
+            ret.frame_dimensions = [frames.attrs[x] for x in ['Nx', 'Ny']]
+
+    return ret
+
 def save_stem_images(outputFile, images, names):
     """Save STEM images to an HDF5 file.
 

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -162,8 +162,8 @@ def save_electron_counts(path, events, scan_dimensions, frame_dimensions=None):
 
         frames[...] = events
 
-def read_electron_counts(path):
-    """Read electron counted data from an HDF5 file.
+def load_electron_counts(path):
+    """Load electron counted data from an HDF5 file.
 
     :param path: path to the HDF5 file.
     :type path: str


### PR DESCRIPTION
Basically, you can now read the electron counted data from an
HDF5 file and then use it to create a stem image like so:
```python
counts = io.read_electron_counts('/path/to/file.h5')
stem_img = image.create_stem_images(counts, inner_radius, outer_radius)[0]
```

You can also now create your own python class that has the attributes
`data`, `scan_dimensions`, and `frame_dimensions`, and you can pass
that into `image.create_stem_images()` to be used as electron counted data.

Fixes: #140 