### PR TITLE
Add support for providing gain mask when electron counting

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -18,7 +18,7 @@ using namespace stempy;
 namespace stempy {
 
 template <typename BlockType>
-CalculateThresholdsResults calculateThresholds(
+CalculateThresholdsResults<uint16_t> calculateThresholds(
   std::vector<BlockType>& blocks, py::array_t<double> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma)
@@ -27,14 +27,90 @@ CalculateThresholdsResults calculateThresholds(
                              backgroundThresholdNSigma, xRayThresholdNSigma);
 }
 
-template CalculateThresholdsResults calculateThresholds(
+template <typename BlockType>
+CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<BlockType>& blocks, py::array_t<double> darkReference,
+  py::array_t<float> gain,
+  int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma)
+{
+  return calculateThresholds(blocks, darkReference.data(), gain.data(), numberOfSamples,
+                             backgroundThresholdNSigma, xRayThresholdNSigma);
+}
+
+template <typename BlockType>
+CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<BlockType>& blocks, Image<double>& darkReference,
+  py::array_t<float> gain, int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma)
+{
+  return calculateThresholds(blocks, darkReference.data.get(), gain.data(), numberOfSamples,
+                             backgroundThresholdNSigma, xRayThresholdNSigma);
+}
+
+template CalculateThresholdsResults<uint16_t> calculateThresholds(
   std::vector<Block>& blocks, py::array_t<double> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
-template CalculateThresholdsResults calculateThresholds(
+template CalculateThresholdsResults<uint16_t> calculateThresholds(
   std::vector<PyBlock>& blocks, py::array_t<double> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
+
+template CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<Block>& blocks, py::array_t<double> darkReference,
+  py::array_t<float> gain, int numberOfSamples,
+  double backgroundThresholdNSigma,  double xRayThresholdNSigma);
+template CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<PyBlock>& blocks, py::array_t<double> darkReference,
+  py::array_t<float> gain,  int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma);
+
+template <typename InputIt>
+ElectronCountedData electronCount(InputIt first, InputIt last,
+                                  py::array_t<double> darkReference,
+                                  py::array_t<float> gain,
+                                  double backgroundThreshold,
+                                  double xRayThreshold,
+                                  Dimensions2D scanDimensions = {0, 0})
+{
+  return electronCount(first, last, darkReference.data(), gain.data(), backgroundThreshold,
+                       xRayThreshold, scanDimensions);
+}
+
+template <typename InputIt>
+ElectronCountedData electronCount(InputIt first, InputIt last,
+                                  Image<double>& darkReference,
+                                  py::array_t<float> gain,
+                                  double backgroundThreshold,
+                                  double xRayThreshold,
+                                  Dimensions2D scanDimensions = {0, 0})
+{
+  return electronCount(first, last, darkReference, gain.data(), backgroundThreshold,
+                       xRayThreshold, scanDimensions);
+}
+
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, py::array_t<double> darkReference,
+  py::array_t<float> gain, int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false)
+{
+  return electronCount(reader, darkReference.data(), gain.data(), thresholdNumberOfBlocks,
+                       numberOfSamples, backgroundThresholdNSigma,
+                       xRayThresholdNSigma, scanDimensions, verbose);
+}
+
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, Image<double>& darkReference,
+  py::array_t<float> gain, int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false)
+{
+  return electronCount(reader, darkReference, gain.data(), thresholdNumberOfBlocks,
+                       numberOfSamples, backgroundThresholdNSigma,
+                       xRayThresholdNSigma, scanDimensions, verbose);
+}
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
@@ -120,26 +196,26 @@ PYBIND11_MODULE(_image, m)
           sizeof(uint16_t) });
     });
 
-  py::class_<CalculateThresholdsResults>(m, "_calculate_thresholds_results",
+  py::class_<CalculateThresholdsResults<uint16_t>>(m, "_calculate_thresholds_results",
                                          py::buffer_protocol())
     .def_readonly("background_threshold",
-                  &CalculateThresholdsResults::backgroundThreshold)
-    .def_readonly("xray_threshold", &CalculateThresholdsResults::xRayThreshold)
+                  &CalculateThresholdsResults<uint16_t>::backgroundThreshold)
+    .def_readonly("xray_threshold", &CalculateThresholdsResults<uint16_t>::xRayThreshold)
     .def_readonly("number_of_samples",
-                  &CalculateThresholdsResults::numberOfSamples)
-    .def_readonly("min_sample", &CalculateThresholdsResults::minSample)
-    .def_readonly("max_sample", &CalculateThresholdsResults::maxSample)
-    .def_readonly("mean", &CalculateThresholdsResults::mean)
-    .def_readonly("variance", &CalculateThresholdsResults::variance)
-    .def_readonly("std_dev", &CalculateThresholdsResults::stdDev)
-    .def_readonly("number_of_bins", &CalculateThresholdsResults::numberOfBins)
+                  &CalculateThresholdsResults<uint16_t>::numberOfSamples)
+    .def_readonly("min_sample", &CalculateThresholdsResults<uint16_t>::minSample)
+    .def_readonly("max_sample", &CalculateThresholdsResults<uint16_t>::maxSample)
+    .def_readonly("mean", &CalculateThresholdsResults<uint16_t>::mean)
+    .def_readonly("variance", &CalculateThresholdsResults<uint16_t>::variance)
+    .def_readonly("std_dev", &CalculateThresholdsResults<uint16_t>::stdDev)
+    .def_readonly("number_of_bins", &CalculateThresholdsResults<uint16_t>::numberOfBins)
     .def_readonly("xray_threshold_n_sigma",
-                  &CalculateThresholdsResults::xRayThresholdNSigma)
+                  &CalculateThresholdsResults<uint16_t>::xRayThresholdNSigma)
     .def_readonly("background_threshold_n_sigma",
-                  &CalculateThresholdsResults::backgroundThresholdNSigma)
-    .def_readonly("optimized_mean", &CalculateThresholdsResults::optimizedMean)
+                  &CalculateThresholdsResults<uint16_t>::backgroundThresholdNSigma)
+    .def_readonly("optimized_mean", &CalculateThresholdsResults<uint16_t>::optimizedMean)
     .def_readonly("optimized_std_dev",
-                  &CalculateThresholdsResults::optimizedStdDev);
+                  &CalculateThresholdsResults<uint16_t>::optimizedStdDev);
 
   py::class_<ElectronCountedData>(m, "_electron_counted_data",
                                   py::buffer_protocol())
@@ -169,6 +245,59 @@ PYBIND11_MODULE(_image, m)
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_average", &calculateAverage<PyReader::iterator>,
         py::call_guard<py::gil_scoped_release>());
+
+  // Electron counting with gain
+  m.def("electron_count",
+        (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
+                                Image<double>&, py::array_t<float>, double,
+                                double, Dimensions2D)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(SectorStreamReader::iterator,
+                                SectorStreamReader::iterator, Image<double>&,
+                                py::array_t<float>, double, double, Dimensions2D)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
+                                Image<double>&, py::array_t<float>, double,
+                                double, Dimensions2D)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
+                                py::array_t<double>, py::array_t<float>, double,
+                                double, Dimensions2D)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(
+          SectorStreamReader::iterator, SectorStreamReader::iterator,
+          py::array_t<double>, py::array_t<float>, double, double, Dimensions2D)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
+                                py::array_t<double>, py::array_t<float>, double,
+                                double, Dimensions2D)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<double>&,
+                                py::array_t<float>, int, int, double, double,
+                                Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def(
+    "electron_count",
+    (ElectronCountedData(*)(SectorStreamThreadedReader*, py::array_t<double>,
+                            py::array_t<float>, int, int, double, double,
+                            Dimensions2D, bool)) &
+      electronCount,
+    py::call_guard<py::gil_scoped_release>());
+
+  // Electron counting, without gain
   m.def("electron_count",
         (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
                                 Image<double>&, double, double, Dimensions2D)) &
@@ -214,23 +343,47 @@ PYBIND11_MODULE(_image, m)
                             int, int, double, double, Dimensions2D, bool)) &
       electronCount,
     py::call_guard<py::gil_scoped_release>());
+
+  // Calculate thresholds, with gain
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults(*)(vector<Block>&, Image<double>&, int,
+        (CalculateThresholdsResults<float>(*)(vector<Block>&, Image<double>&,
+          py::array_t<float>, int, double, double)) &
+          calculateThresholds,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("calculate_thresholds",
+        (CalculateThresholdsResults<float>(*)(vector<PyBlock>&, Image<double>&,
+          py::array_t<float>, int, double, double)) &
+          calculateThresholds,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("calculate_thresholds",
+        (CalculateThresholdsResults<float>(*)(vector<Block>&, py::array_t<double>,
+          py::array_t<float>, int, double, double)) &
+          calculateThresholds,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("calculate_thresholds",
+        (CalculateThresholdsResults<float>(*)(vector<PyBlock>&, py::array_t<double>,
+          py::array_t<float>, int, double, double)) &
+          calculateThresholds,
+        py::call_guard<py::gil_scoped_release>());
+
+  // Calculate thresholds, without gain
+  m.def("calculate_thresholds",
+        (CalculateThresholdsResults<uint16_t>(*)(vector<Block>&, Image<double>&, int,
                                        double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults(*)(vector<PyBlock>&, Image<double>&, int,
+        (CalculateThresholdsResults<uint16_t>(*)(vector<PyBlock>&, Image<double>&, int,
                                        double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults(*)(vector<Block>&, py::array_t<double>, int,
+        (CalculateThresholdsResults<uint16_t>(*)(vector<Block>&, py::array_t<double>, int,
                                        double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults(*)(vector<PyBlock>&, py::array_t<double>,
+        (CalculateThresholdsResults<uint16_t>(*)(vector<PyBlock>&, py::array_t<double>,
                                        int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -30,22 +30,23 @@ CalculateThresholdsResults<uint16_t> calculateThresholds(
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
   std::vector<BlockType>& blocks, py::array_t<double> darkReference,
-  py::array_t<float> gain,
-  int numberOfSamples, double backgroundThresholdNSigma,
-  double xRayThresholdNSigma)
+  py::array_t<float> gain, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma)
 {
-  return calculateThresholds(blocks, darkReference.data(), gain.data(), numberOfSamples,
-                             backgroundThresholdNSigma, xRayThresholdNSigma);
+  return calculateThresholds(blocks, darkReference.data(), gain.data(),
+                             numberOfSamples, backgroundThresholdNSigma,
+                             xRayThresholdNSigma);
 }
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
   std::vector<BlockType>& blocks, Image<double>& darkReference,
-  py::array_t<float> gain, int numberOfSamples, double backgroundThresholdNSigma,
-  double xRayThresholdNSigma)
+  py::array_t<float> gain, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma)
 {
-  return calculateThresholds(blocks, darkReference.data.get(), gain.data(), numberOfSamples,
-                             backgroundThresholdNSigma, xRayThresholdNSigma);
+  return calculateThresholds(blocks, darkReference.data.get(), gain.data(),
+                             numberOfSamples, backgroundThresholdNSigma,
+                             xRayThresholdNSigma);
 }
 
 template CalculateThresholdsResults<uint16_t> calculateThresholds(
@@ -60,11 +61,11 @@ template CalculateThresholdsResults<uint16_t> calculateThresholds(
 template CalculateThresholdsResults<float> calculateThresholds(
   std::vector<Block>& blocks, py::array_t<double> darkReference,
   py::array_t<float> gain, int numberOfSamples,
-  double backgroundThresholdNSigma,  double xRayThresholdNSigma);
+  double backgroundThresholdNSigma, double xRayThresholdNSigma);
 template CalculateThresholdsResults<float> calculateThresholds(
   std::vector<PyBlock>& blocks, py::array_t<double> darkReference,
-  py::array_t<float> gain,  int numberOfSamples, double backgroundThresholdNSigma,
-  double xRayThresholdNSigma);
+  py::array_t<float> gain, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma);
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
@@ -72,10 +73,10 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
                                   py::array_t<float> gain,
                                   double backgroundThreshold,
                                   double xRayThreshold,
-                                  Dimensions2D scanDimensions = {0, 0})
+                                  Dimensions2D scanDimensions = { 0, 0 })
 {
-  return electronCount(first, last, darkReference.data(), gain.data(), backgroundThreshold,
-                       xRayThreshold, scanDimensions);
+  return electronCount(first, last, darkReference.data(), gain.data(),
+                       backgroundThreshold, xRayThreshold, scanDimensions);
 }
 
 template <typename InputIt>
@@ -84,10 +85,10 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
                                   py::array_t<float> gain,
                                   double backgroundThreshold,
                                   double xRayThreshold,
-                                  Dimensions2D scanDimensions = {0, 0})
+                                  Dimensions2D scanDimensions = { 0, 0 })
 {
-  return electronCount(first, last, darkReference, gain.data(), backgroundThreshold,
-                       xRayThreshold, scanDimensions);
+  return electronCount(first, last, darkReference, gain.data(),
+                       backgroundThreshold, xRayThreshold, scanDimensions);
 }
 
 ElectronCountedData electronCount(
@@ -96,9 +97,10 @@ ElectronCountedData electronCount(
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false)
 {
-  return electronCount(reader, darkReference.data(), gain.data(), thresholdNumberOfBlocks,
-                       numberOfSamples, backgroundThresholdNSigma,
-                       xRayThresholdNSigma, scanDimensions, verbose);
+  return electronCount(reader, darkReference.data(), gain.data(),
+                       thresholdNumberOfBlocks, numberOfSamples,
+                       backgroundThresholdNSigma, xRayThresholdNSigma,
+                       scanDimensions, verbose);
 }
 
 ElectronCountedData electronCount(
@@ -107,9 +109,10 @@ ElectronCountedData electronCount(
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false)
 {
-  return electronCount(reader, darkReference, gain.data(), thresholdNumberOfBlocks,
-                       numberOfSamples, backgroundThresholdNSigma,
-                       xRayThresholdNSigma, scanDimensions, verbose);
+  return electronCount(reader, darkReference, gain.data(),
+                       thresholdNumberOfBlocks, numberOfSamples,
+                       backgroundThresholdNSigma, xRayThresholdNSigma,
+                       scanDimensions, verbose);
 }
 
 template <typename InputIt>
@@ -196,24 +199,30 @@ PYBIND11_MODULE(_image, m)
           sizeof(uint16_t) });
     });
 
-  py::class_<CalculateThresholdsResults<uint16_t>>(m, "_calculate_thresholds_results",
-                                         py::buffer_protocol())
+  py::class_<CalculateThresholdsResults<uint16_t>>(
+    m, "_calculate_thresholds_results", py::buffer_protocol())
     .def_readonly("background_threshold",
                   &CalculateThresholdsResults<uint16_t>::backgroundThreshold)
-    .def_readonly("xray_threshold", &CalculateThresholdsResults<uint16_t>::xRayThreshold)
+    .def_readonly("xray_threshold",
+                  &CalculateThresholdsResults<uint16_t>::xRayThreshold)
     .def_readonly("number_of_samples",
                   &CalculateThresholdsResults<uint16_t>::numberOfSamples)
-    .def_readonly("min_sample", &CalculateThresholdsResults<uint16_t>::minSample)
-    .def_readonly("max_sample", &CalculateThresholdsResults<uint16_t>::maxSample)
+    .def_readonly("min_sample",
+                  &CalculateThresholdsResults<uint16_t>::minSample)
+    .def_readonly("max_sample",
+                  &CalculateThresholdsResults<uint16_t>::maxSample)
     .def_readonly("mean", &CalculateThresholdsResults<uint16_t>::mean)
     .def_readonly("variance", &CalculateThresholdsResults<uint16_t>::variance)
     .def_readonly("std_dev", &CalculateThresholdsResults<uint16_t>::stdDev)
-    .def_readonly("number_of_bins", &CalculateThresholdsResults<uint16_t>::numberOfBins)
+    .def_readonly("number_of_bins",
+                  &CalculateThresholdsResults<uint16_t>::numberOfBins)
     .def_readonly("xray_threshold_n_sigma",
                   &CalculateThresholdsResults<uint16_t>::xRayThresholdNSigma)
-    .def_readonly("background_threshold_n_sigma",
-                  &CalculateThresholdsResults<uint16_t>::backgroundThresholdNSigma)
-    .def_readonly("optimized_mean", &CalculateThresholdsResults<uint16_t>::optimizedMean)
+    .def_readonly(
+      "background_threshold_n_sigma",
+      &CalculateThresholdsResults<uint16_t>::backgroundThresholdNSigma)
+    .def_readonly("optimized_mean",
+                  &CalculateThresholdsResults<uint16_t>::optimizedMean)
     .def_readonly("optimized_std_dev",
                   &CalculateThresholdsResults<uint16_t>::optimizedStdDev);
 
@@ -254,9 +263,9 @@ PYBIND11_MODULE(_image, m)
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        (ElectronCountedData(*)(SectorStreamReader::iterator,
-                                SectorStreamReader::iterator, Image<double>&,
-                                py::array_t<float>, double, double, Dimensions2D)) &
+        (ElectronCountedData(*)(
+          SectorStreamReader::iterator, SectorStreamReader::iterator,
+          Image<double>&, py::array_t<float>, double, double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
@@ -271,12 +280,13 @@ PYBIND11_MODULE(_image, m)
                                 double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
-  m.def("electron_count",
-        (ElectronCountedData(*)(
-          SectorStreamReader::iterator, SectorStreamReader::iterator,
-          py::array_t<double>, py::array_t<float>, double, double, Dimensions2D)) &
-          electronCount,
-        py::call_guard<py::gil_scoped_release>());
+  m.def(
+    "electron_count",
+    (ElectronCountedData(*)(SectorStreamReader::iterator,
+                            SectorStreamReader::iterator, py::array_t<double>,
+                            py::array_t<float>, double, double, Dimensions2D)) &
+      electronCount,
+    py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
                                 py::array_t<double>, py::array_t<float>, double,
@@ -289,13 +299,12 @@ PYBIND11_MODULE(_image, m)
                                 Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
-  m.def(
-    "electron_count",
-    (ElectronCountedData(*)(SectorStreamThreadedReader*, py::array_t<double>,
-                            py::array_t<float>, int, int, double, double,
-                            Dimensions2D, bool)) &
-      electronCount,
-    py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(SectorStreamThreadedReader*,
+                                py::array_t<double>, py::array_t<float>, int,
+                                int, double, double, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
 
   // Electron counting, without gain
   m.def("electron_count",
@@ -347,44 +356,48 @@ PYBIND11_MODULE(_image, m)
   // Calculate thresholds, with gain
   m.def("calculate_thresholds",
         (CalculateThresholdsResults<float>(*)(vector<Block>&, Image<double>&,
-          py::array_t<float>, int, double, double)) &
+                                              py::array_t<float>, int, double,
+                                              double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
         (CalculateThresholdsResults<float>(*)(vector<PyBlock>&, Image<double>&,
-          py::array_t<float>, int, double, double)) &
+                                              py::array_t<float>, int, double,
+                                              double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults<float>(*)(vector<Block>&, py::array_t<double>,
-          py::array_t<float>, int, double, double)) &
+        (CalculateThresholdsResults<float>(*)(
+          vector<Block>&, py::array_t<double>, py::array_t<float>, int, double,
+          double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults<float>(*)(vector<PyBlock>&, py::array_t<double>,
-          py::array_t<float>, int, double, double)) &
+        (CalculateThresholdsResults<float>(*)(
+          vector<PyBlock>&, py::array_t<double>, py::array_t<float>, int,
+          double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
 
   // Calculate thresholds, without gain
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults<uint16_t>(*)(vector<Block>&, Image<double>&, int,
-                                       double, double)) &
+        (CalculateThresholdsResults<uint16_t>(*)(vector<Block>&, Image<double>&,
+                                                 int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults<uint16_t>(*)(vector<PyBlock>&, Image<double>&, int,
-                                       double, double)) &
+        (CalculateThresholdsResults<uint16_t>(*)(
+          vector<PyBlock>&, Image<double>&, int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults<uint16_t>(*)(vector<Block>&, py::array_t<double>, int,
-                                       double, double)) &
+        (CalculateThresholdsResults<uint16_t>(*)(
+          vector<Block>&, py::array_t<double>, int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults<uint16_t>(*)(vector<PyBlock>&, py::array_t<double>,
-                                       int, double, double)) &
+        (CalculateThresholdsResults<uint16_t>(*)(
+          vector<PyBlock>&, py::array_t<double>, int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("radial_sum", &radialSum<StreamReader::iterator>,

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -77,7 +77,8 @@ private:
   double m_upper;
 };
 
-struct ApplyGainSubtractAndThreshold : public vtkm::worklet::WorkletMapCellToPoint
+struct ApplyGainSubtractAndThreshold
+  : public vtkm::worklet::WorkletMapCellToPoint
 {
   using CountingHandle = vtkm::cont::ArrayHandleCounting<vtkm::Id>;
 
@@ -104,9 +105,7 @@ private:
   double m_upper;
 };
 
-
-
-template<typename FrameType>
+template <typename FrameType>
 std::vector<uint32_t> maximalPointsParallel(std::vector<FrameType>& frame,
                                             Dimensions2D frameDimensions,
                                             const double* darkReferenceData,
@@ -134,32 +133,34 @@ std::vector<uint32_t> maximalPointsParallel(std::vector<FrameType>& frame,
   // Call the correct worklet based on whether we are applying a gain, which in
   // term determines the type, so can be evaluated a compile time.
   // First no gain
-  if(std::is_integral<FrameType>::value) {
+  if (std::is_integral<FrameType>::value) {
     // Background subtraction and thresholding
     invoke(SubtractAndThreshold{ backgroundThreshold, xRayThreshold }, cellSet,
-          frameHandle, darkRefHandle);
-  // We are applying a gain
-  else {
-    auto gainRefHandle = vtkm::cont::make_ArrayHandle(
+           frameHandle, darkRefHandle);
+    // We are applying a gain
+    else
+    {
+      auto gainRefHandle = vtkm::cont::make_ArrayHandle(
         gain, frameDimensions.first * frameDimensions.second);
-    // Apply gain, background subtraction and thresholding
-    invoke(ApplyGainSubtractAndThreshold{ backgroundThreshold, xRayThreshold }, cellSet,
-          frameHandle, darkRefHandle, gainRefHandle);
-  }
-  // Find maximal pixels
-  invoke(IsMaximalPixel{}, cellSet, frameHandle, maximalPixels);
+      // Apply gain, background subtraction and thresholding
+      invoke(
+        ApplyGainSubtractAndThreshold{ backgroundThreshold, xRayThreshold },
+        cellSet, frameHandle, darkRefHandle, gainRefHandle);
+    }
+    // Find maximal pixels
+    invoke(IsMaximalPixel{}, cellSet, frameHandle, maximalPixels);
 
-  // Convert to std::vector<uint32_t>
-  auto maximalPixelsPortal = maximalPixels.GetPortalConstControl();
-  std::vector<uint32_t> outputVec;
-  for (vtkm::Id i = 0; i < maximalPixelsPortal.GetNumberOfValues(); ++i) {
-    if (maximalPixelsPortal.Get(i))
-      outputVec.push_back(i);
-  }
+    // Convert to std::vector<uint32_t>
+    auto maximalPixelsPortal = maximalPixels.GetPortalConstControl();
+    std::vector<uint32_t> outputVec;
+    for (vtkm::Id i = 0; i < maximalPixelsPortal.GetNumberOfValues(); ++i) {
+      if (maximalPixelsPortal.Get(i))
+        outputVec.push_back(i);
+    }
 
-  // Done
-  return outputVec;
-}
+    // Done
+    return outputVec;
+  }
 } // end namespace
 #endif
 
@@ -173,7 +174,7 @@ inline uint16_t mod(uint16_t x, uint16_t y)
 
 // Return the points in the frame with values larger than all 8 of their nearest
 // neighbors
-template<typename FrameType>
+template <typename FrameType>
 std::vector<uint32_t> maximalPoints(const std::vector<FrameType>& frame,
                                     Dimensions2D frameDimensions)
 {
@@ -243,12 +244,9 @@ std::vector<uint32_t> maximalPoints(const std::vector<FrameType>& frame,
 }
 
 template <typename InputIt, typename FrameType>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const double darkReference[],
-                                  const float gain[],
-                                  double backgroundThreshold,
-                                  double xRayThreshold,
-                                  Dimensions2D scanDimensions)
+ElectronCountedData electronCount(
+  InputIt first, InputIt last, const double darkReference[], const float gain[],
+  double backgroundThreshold, double xRayThreshold, Dimensions2D scanDimensions)
 {
   if (first == last) {
     std::ostringstream msg;
@@ -282,21 +280,20 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
       auto frameStart =
         data + i * frameDimensions.first * frameDimensions.second;
       std::vector<FrameType> frame(frameStart,
-                                  frameStart + frameDimensions.first *
-                                                 frameDimensions.second);
+                                   frameStart + frameDimensions.first *
+                                                  frameDimensions.second);
 
 #ifdef VTKm
       events[block.header.imageNumbers[i]] =
         maximalPointsParallel<FrameType>(frame, frameDimensions, darkReference,
-                              backgroundThreshold, xRayThreshold);
+                                         backgroundThreshold, xRayThreshold);
 #else
       for (int j = 0; j < frameDimensions.first * frameDimensions.second; j++) {
         // Subtract darkfield reference and apply gain if we have one, this will
         // be based on our template type, it can be evaluated a compile time.
-        if(std::is_integral<FrameType>::value) {
+        if (std::is_integral<FrameType>::value) {
           frame[j] -= darkReference[j];
-        }
-        else {
+        } else {
           frame[j] = frame[i] * gain[i] - darkReference[j];
         }
         // Threshold the electron events
@@ -332,29 +329,23 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 }
 
 template <typename InputIt>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const double darkReference[],
-                                  const float gain[],
-                                  double backgroundThreshold,
-                                  double xRayThreshold,
-                                  Dimensions2D scanDimensions)
+ElectronCountedData electronCount(
+  InputIt first, InputIt last, const double darkReference[], const float gain[],
+  double backgroundThreshold, double xRayThreshold, Dimensions2D scanDimensions)
 {
   return electronCount<InputIt, float>(first, last, darkReference, gain,
-                                          backgroundThreshold, xRayThreshold,
-                                          scanDimensions);
+                                       backgroundThreshold, xRayThreshold,
+                                       scanDimensions);
 }
 
-
 template <typename InputIt>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<double>& darkReference,
-                                  const float gain[],
-                                  double backgroundThreshold,
-                                  double xRayThreshold,
-                                  Dimensions2D scanDimensions)
+ElectronCountedData electronCount(
+  InputIt first, InputIt last, Image<double>& darkReference, const float gain[],
+  double backgroundThreshold, double xRayThreshold, Dimensions2D scanDimensions)
 {
-  return electronCount<InputIt, float>(first, last, darkReference.data.get(), gain,
-                       backgroundThreshold, xRayThreshold, scanDimensions);
+  return electronCount<InputIt, float>(first, last, darkReference.data.get(),
+                                       gain, backgroundThreshold, xRayThreshold,
+                                       scanDimensions);
 }
 
 template <typename InputIt>
@@ -365,9 +356,8 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
                                   Dimensions2D scanDimensions)
 {
   return electronCount<InputIt, uint16_t>(first, last, darkReference.data.get(),
-                                          nullptr, backgroundThreshold, xRayThreshold,
-                                          scanDimensions);
-
+                                          nullptr, backgroundThreshold,
+                                          xRayThreshold, scanDimensions);
 }
 
 template <typename FrameType>
@@ -382,10 +372,9 @@ std::vector<uint32_t> electronCount(std::vector<FrameType>& frame,
   for (int j = 0; j < frameDimensions.first * frameDimensions.second; j++) {
     // Subtract darkfield reference and apply gain if we have one, this will
     // be based on our template type, it can be evaluated a compile time.
-    if(std::is_integral<FrameType>::value) {
+    if (std::is_integral<FrameType>::value) {
       frame[j] -= darkReference[j];
-    }
-    else {
+    } else {
       frame[j] = frame[j] * gain[j] - darkReference[j];
     }
     // Threshold the electron events
@@ -404,9 +393,8 @@ std::vector<uint32_t> electronCount(std::vector<uint16_t>& frame,
                                     double xRayThreshold)
 {
   return electronCount<uint16_t>(frame, frameDimensions, darkReference, nullptr,
-                                 backgroundThreshold, xRayThreshold );
+                                 backgroundThreshold, xRayThreshold);
 }
-
 
 std::vector<uint32_t> electronCount(std::vector<float>& frame,
                                     Dimensions2D frameDimensions,
@@ -416,19 +404,15 @@ std::vector<uint32_t> electronCount(std::vector<float>& frame,
                                     double xRayThreshold)
 {
   return electronCount<float>(frame, frameDimensions, darkReference, gain,
-                                 backgroundThreshold, xRayThreshold );
+                              backgroundThreshold, xRayThreshold);
 }
 
-
 template <typename FrameType>
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
-                                  const double darkReference[],
-                                  const float gain[],
-                                  int thresholdNumberOfBlocks,
-                                  int numberOfSamples,
-                                  double backgroundThresholdNSigma,
-                                  double xRayThresholdNSigma,
-                                  Dimensions2D scanDimensions, bool verbose)
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, const double darkReference[],
+  const float gain[], int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  Dimensions2D scanDimensions, bool verbose)
 {
   // This is where we will save the electron events as the calculated
   std::vector<std::vector<uint32_t>> events;
@@ -450,9 +434,8 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
 
   auto counter = [&events, &electronCounting, &backgroundThreshold,
                   &xRayThreshold, &sampleMutex, &sampleCondition, &sampleBlocks,
-                  thresholdNumberOfBlocks, numberOfSamples,
-                  darkReference, gain](Block& b) {
-
+                  thresholdNumberOfBlocks, numberOfSamples, darkReference,
+                  gain](Block& b) {
     // If we are still collecting sample block for calculating the threshold
     if (!electronCounting) {
       std::unique_lock<std::mutex> sampleLock(sampleMutex);
@@ -479,11 +462,12 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
         auto frameStart =
           data + i * frameDimensions.first * frameDimensions.second;
         std::vector<FrameType> frame(frameStart,
-                                    frameStart + frameDimensions.first *
-                                                   frameDimensions.second);
+                                     frameStart + frameDimensions.first *
+                                                    frameDimensions.second);
 
-        auto frameEvents = electronCount<FrameType>(frame, frameDimensions, darkReference, gain,
-                                                    backgroundThreshold, xRayThreshold);
+        auto frameEvents =
+          electronCount<FrameType>(frame, frameDimensions, darkReference, gain,
+                                   backgroundThreshold, xRayThreshold);
         events[b.header.imageNumbers[i]] = frameEvents;
       }
     }
@@ -544,10 +528,10 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
         data + i * frameDimensions.first * frameDimensions.second;
       std::vector<FrameType> frame(frameStart,
                                    frameStart + frameDimensions.first *
-                                                frameDimensions.second);
-      auto frameEvents = electronCount<FrameType>(frame, frameDimensions, darkReference,
-                                                  gain, backgroundThreshold,
-                                                  xRayThreshold);
+                                                  frameDimensions.second);
+      auto frameEvents =
+        electronCount<FrameType>(frame, frameDimensions, darkReference, gain,
+                                 backgroundThreshold, xRayThreshold);
       events[b.header.imageNumbers[i]] = frameEvents;
     }
   }
@@ -563,32 +547,27 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
   return ret;
 }
 
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
-                                  const double darkReference[],
-                                  const float gain[],
-                                  int thresholdNumberOfBlocks,
-                                  int numberOfSamples,
-                                  double backgroundThresholdNSigma,
-                                  double xRayThresholdNSigma,
-                                  Dimensions2D scanDimensions, bool verbose)
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, const double darkReference[],
+  const float gain[], int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  Dimensions2D scanDimensions, bool verbose)
 {
   return electronCount<float>(
     reader, darkReference, gain, thresholdNumberOfBlocks, numberOfSamples,
     backgroundThresholdNSigma, xRayThresholdNSigma, scanDimensions, verbose);
 }
 
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
-                                  Image<double>& darkReference,
-                                  const float gain[],
-                                  int thresholdNumberOfBlocks,
-                                  int numberOfSamples,
-                                  double backgroundThresholdNSigma,
-                                  double xRayThresholdNSigma,
-                                  Dimensions2D scanDimensions, bool verbose)
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, Image<double>& darkReference,
+  const float gain[], int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<float>(
-    reader, darkReference.data.get(), gain, thresholdNumberOfBlocks, numberOfSamples,
-    backgroundThresholdNSigma, xRayThresholdNSigma, scanDimensions, verbose);
+  return electronCount<float>(reader, darkReference.data.get(), gain,
+                              thresholdNumberOfBlocks, numberOfSamples,
+                              backgroundThresholdNSigma, xRayThresholdNSigma,
+                              scanDimensions, verbose);
 }
 
 ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
@@ -599,9 +578,9 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
                                   double xRayThresholdNSigma,
                                   Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<uint16_t>(reader, darkReference, nullptr, thresholdNumberOfBlocks,
-                                 numberOfSamples, backgroundThresholdNSigma,
-                                 xRayThresholdNSigma, scanDimensions, verbose);
+  return electronCount<uint16_t>(
+    reader, darkReference, nullptr, thresholdNumberOfBlocks, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma, scanDimensions, verbose);
 }
 
 ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
@@ -612,57 +591,39 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
                                   double xRayThresholdNSigma,
                                   Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<uint16_t>(reader, darkReference.data.get(), nullptr, thresholdNumberOfBlocks,
-                                 numberOfSamples, backgroundThresholdNSigma,
-                                 xRayThresholdNSigma, scanDimensions, verbose);
+  return electronCount<uint16_t>(reader, darkReference.data.get(), nullptr,
+                                 thresholdNumberOfBlocks, numberOfSamples,
+                                 backgroundThresholdNSigma, xRayThresholdNSigma,
+                                 scanDimensions, verbose);
 }
 
 // Instantiate the ones that can be used
 
 // With gain
-template ElectronCountedData electronCount(StreamReader::iterator first,
-                                           StreamReader::iterator last,
-                                           Image<double>& darkReference,
-                                           const float gain[],
-                                           double backgroundThreshold,
-                                           double xRayThreshold,
-                                           Dimensions2D scanDimensions);
-template ElectronCountedData electronCount(StreamReader::iterator first,
-                                           StreamReader::iterator last,
-                                           const double darkReference[],
-                                           const float gain[],
-                                           double backgroundThreshold,
-                                           double xRayThreshold,
-                                           Dimensions2D scanDimensions);
-template ElectronCountedData electronCount(SectorStreamReader::iterator first,
-                                           SectorStreamReader::iterator last,
-                                           Image<double>& darkReference,
-                                           const float gain[],
-                                           double backgroundThreshold,
-                                           double xRayThreshold,
-                                           Dimensions2D scanDimensions);
-template ElectronCountedData electronCount(SectorStreamReader::iterator first,
-                                           SectorStreamReader::iterator last,
-                                           const double darkReference[],
-                                           const float gain[],
-                                           double backgroundThreshold,
-                                           double xRayThreshold,
-                                           Dimensions2D scanDimensions);
-template ElectronCountedData electronCount(PyReader::iterator first,
-                                           PyReader::iterator last,
-                                           Image<double>& darkReference,
-                                           const float gain[],
-                                           double backgroundThreshold,
-                                           double xRayThreshold,
-                                           Dimensions2D scanDimensions);
-template ElectronCountedData electronCount(PyReader::iterator first,
-                                           PyReader::iterator last,
-                                           const double darkReference[],
-                                           const float gain[],
-                                           double backgroundThreshold,
-                                           double xRayThreshold,
-                                           Dimensions2D scanDimensions);
-
+template ElectronCountedData electronCount(
+  StreamReader::iterator first, StreamReader::iterator last,
+  Image<double>& darkReference, const float gain[], double backgroundThreshold,
+  double xRayThreshold, Dimensions2D scanDimensions);
+template ElectronCountedData electronCount(
+  StreamReader::iterator first, StreamReader::iterator last,
+  const double darkReference[], const float gain[], double backgroundThreshold,
+  double xRayThreshold, Dimensions2D scanDimensions);
+template ElectronCountedData electronCount(
+  SectorStreamReader::iterator first, SectorStreamReader::iterator last,
+  Image<double>& darkReference, const float gain[], double backgroundThreshold,
+  double xRayThreshold, Dimensions2D scanDimensions);
+template ElectronCountedData electronCount(
+  SectorStreamReader::iterator first, SectorStreamReader::iterator last,
+  const double darkReference[], const float gain[], double backgroundThreshold,
+  double xRayThreshold, Dimensions2D scanDimensions);
+template ElectronCountedData electronCount(
+  PyReader::iterator first, PyReader::iterator last,
+  Image<double>& darkReference, const float gain[], double backgroundThreshold,
+  double xRayThreshold, Dimensions2D scanDimensions);
+template ElectronCountedData electronCount(
+  PyReader::iterator first, PyReader::iterator last,
+  const double darkReference[], const float gain[], double backgroundThreshold,
+  double xRayThreshold, Dimensions2D scanDimensions);
 
 // Without gain
 template ElectronCountedData electronCount(StreamReader::iterator first,

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -59,7 +59,7 @@ ElectronCountedData electronCount(
 
 ElectronCountedData electronCount(
   SectorStreamThreadedReader* reader, Image<double>& darkreference,
-  const  float gain[], int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  const float gain[], int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
@@ -68,7 +68,6 @@ ElectronCountedData electronCount(
   const float gain[], int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
-
 }
 
 #endif /* STEMPY_ELECTRON_H_ */

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -29,6 +29,22 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
                                   double xRayThreshold,
                                   Dimensions2D scanDimensions = { 0, 0 });
 
+template <typename InputIt>
+ElectronCountedData electronCount(InputIt first, InputIt last,
+                                  Image<double>& darkreference,
+                                  const float gain[],
+                                  double backgroundThreshold,
+                                  double xRayThreshold,
+                                  Dimensions2D scanDimensions = { 0, 0 });
+
+template <typename InputIt>
+ElectronCountedData electronCount(InputIt first, InputIt last,
+                                  const double darkreference[],
+                                  const float gain[],
+                                  double backgroundThreshold,
+                                  double xRayThreshold,
+                                  Dimensions2D scanDimensions = { 0, 0 });
+
 ElectronCountedData electronCount(
   SectorStreamThreadedReader* reader, Image<double>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
@@ -40,6 +56,19 @@ ElectronCountedData electronCount(
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, Image<double>& darkreference,
+  const  float gain[], int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, const double darkreference[],
+  const float gain[], int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
 }
 
 #endif /* STEMPY_ELECTRON_H_ */

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -10,12 +10,14 @@
 
 namespace stempy {
 
-double calculateMean(std::vector<int16_t>& values)
+template<typename T>
+double calculateMean(std::vector<T>& values)
 {
   return std::accumulate(values.begin(), values.end(), 0.0) / values.size();
 }
 
-double calculateVariance(std::vector<int16_t>& values, double mean)
+template<typename T>
+double calculateVariance(std::vector<T>& values, double mean)
 {
   double v1 = 0;
   double sigma2;
@@ -69,9 +71,10 @@ struct GaussianErrorFunctor : Eigen::DenseFunctor<double>
   Eigen::VectorXd m_histogram;
 };
 
-template <typename BlockType>
-CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
+template <typename BlockType, typename FrameType>
+CalculateThresholdsResults<FrameType> calculateThresholds(std::vector<BlockType>& blocks,
                                                const double darkReference[],
+                                               const float gain[],
                                                int numberOfSamples,
                                                double backgroundThresholdNSigma,
                                                double xRayThresholdNSigma)
@@ -85,7 +88,7 @@ CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
 
   int numberSamplePixels =
     frameDimensions.first * frameDimensions.second * numberOfSamples;
-  std::vector<int16_t> samples(numberSamplePixels, 0);
+  std::vector<FrameType> samples(numberSamplePixels, 0);
   for (int i = 0; i < numberOfSamples; i++) {
     std::uniform_int_distribution<int> randomBlockDist(0, blocks.size() - 1);
     auto randomBlockIndex = randomBlockDist(randomEngine);
@@ -98,9 +101,19 @@ CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
     for (unsigned j = 0; j < numberOfPixels; j++) {
       // For now just use the index, the image number don't seem to work, in the
       // current data set. In the future we should be using the image number.
-      samples[i * numberOfPixels + j] =
-        blockData[randomFrameIndex * numberOfPixels + j] -
-        static_cast<int16_t>(darkReference[j]);
+
+      // This will be evaluated a compile time.
+      if(std::is_integral<FrameType>::value) {
+        samples[i * numberOfPixels + j] =
+          blockData[randomFrameIndex * numberOfPixels + j] -
+          static_cast<int16_t>(darkReference[j]);
+      }
+      // if not integral type then we know we have gain and need to muliple
+      else {
+        samples[i * numberOfPixels + j] =
+          blockData[randomFrameIndex * numberOfPixels + j] * gain[j] -
+          static_cast<float>(darkReference[j]);
+      }
     }
   }
 
@@ -113,7 +126,7 @@ CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
   // Now generate a histograms
   auto minMax = std::minmax_element(samples.begin(), samples.end());
   auto minSample = *minMax.first;
-  auto maxSample = static_cast<int16_t>(std::ceil(*minMax.second));
+  auto maxSample = static_cast<FrameType>(std::ceil(*minMax.second));
   auto maxBin = std::min(static_cast<int>(maxSample),
                          static_cast<int>(mean + xrayThreshold * stdDev));
   auto minBin = std::max(static_cast<int>(minSample),
@@ -160,7 +173,7 @@ CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
   auto backgroundThreshold =
     optimizedMean + optimizedStdDev * backgroundThresholdNSigma;
 
-  CalculateThresholdsResults ret;
+  CalculateThresholdsResults<FrameType> ret;
   ret.numberOfSamples = numberOfSamples;
   ret.minSample = minSample;
   ret.maxSample = maxSample;
@@ -178,28 +191,77 @@ CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
   return ret;
 }
 
+
+// Without gain
 template <typename BlockType>
-CalculateThresholdsResults calculateThresholds(std::vector<BlockType>& blocks,
-                                               Image<double>& darkReference,
-                                               int numberOfSamples,
-                                               double backgroundThresholdNSigma,
-                                               double xRayThresholdNSigma)
+CalculateThresholdsResults<uint16_t> calculateThresholds(
+  std::vector<BlockType>& blocks, Image<double>& darkreference,
+  int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma) {
+    return calculateThresholds<BlockType, uint16_t>(blocks, darkreference.data.get(),
+      nullptr, numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
+  }
+
+template <typename BlockType>
+CalculateThresholdsResults<uint16_t> calculateThresholds(
+  std::vector<BlockType>& blocks, const double darkreference[],
+  int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma)
 {
-  return calculateThresholds(blocks, darkReference.data.get(), numberOfSamples,
-                             backgroundThresholdNSigma, xRayThresholdNSigma);
+    return calculateThresholds<BlockType, uint16_t>(blocks, darkreference, nullptr,
+        numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
 }
 
-template CalculateThresholdsResults calculateThresholds<Block>(
+// With gain
+template <typename BlockType>
+CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<BlockType>& blocks, Image<double>& darkreference,
+  const float gain[], int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma)
+{
+    return calculateThresholds<BlockType, float>(blocks, darkreference.data.get(),
+      gain, numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
+}
+
+template <typename BlockType>
+CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<BlockType>& blocks, const double darkreference[],
+  const float gain[], int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma) {
+    return calculateThresholds<BlockType, float>(blocks, darkreference,
+      gain, numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
+  }
+
+
+
+// With gain
+template CalculateThresholdsResults<float> calculateThresholds<Block>(
+  std::vector<Block>& blocks, Image<double>& darkReference, const float gain[], int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma);
+template CalculateThresholdsResults<float> calculateThresholds<PyBlock>(
+  std::vector<PyBlock>& blocks, Image<double>& darkReference, const float gain[],
+  int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma);
+template CalculateThresholdsResults<float> calculateThresholds<Block>(
+  std::vector<Block>& blocks, const double darkReference[], const float gain[], int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma);
+template CalculateThresholdsResults<float> calculateThresholds<PyBlock>(
+  std::vector<PyBlock>& blocks, const double darkReference[], const float gain[],
+  int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma);
+
+// No gain
+template CalculateThresholdsResults<uint16_t> calculateThresholds<Block>(
   std::vector<Block>& blocks, Image<double>& darkReference, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma);
-template CalculateThresholdsResults calculateThresholds<PyBlock>(
+template CalculateThresholdsResults<uint16_t> calculateThresholds<PyBlock>(
   std::vector<PyBlock>& blocks, Image<double>& darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
-template CalculateThresholdsResults calculateThresholds<Block>(
+template CalculateThresholdsResults<uint16_t> calculateThresholds<Block>(
   std::vector<Block>& blocks, const double darkReference[], int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma);
-template CalculateThresholdsResults calculateThresholds<PyBlock>(
+template CalculateThresholdsResults<uint16_t> calculateThresholds<PyBlock>(
   std::vector<PyBlock>& blocks, const double darkReference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -10,13 +10,13 @@
 
 namespace stempy {
 
-template<typename T>
+template <typename T>
 double calculateMean(std::vector<T>& values)
 {
   return std::accumulate(values.begin(), values.end(), 0.0) / values.size();
 }
 
-template<typename T>
+template <typename T>
 double calculateVariance(std::vector<T>& values, double mean)
 {
   double v1 = 0;
@@ -72,12 +72,10 @@ struct GaussianErrorFunctor : Eigen::DenseFunctor<double>
 };
 
 template <typename BlockType, typename FrameType>
-CalculateThresholdsResults<FrameType> calculateThresholds(std::vector<BlockType>& blocks,
-                                               const double darkReference[],
-                                               const float gain[],
-                                               int numberOfSamples,
-                                               double backgroundThresholdNSigma,
-                                               double xRayThresholdNSigma)
+CalculateThresholdsResults<FrameType> calculateThresholds(
+  std::vector<BlockType>& blocks, const double darkReference[],
+  const float gain[], int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma)
 {
   auto frameDimensions = blocks[0].header.frameDimensions;
   auto numberOfPixels = frameDimensions.first * frameDimensions.second;
@@ -103,7 +101,7 @@ CalculateThresholdsResults<FrameType> calculateThresholds(std::vector<BlockType>
       // current data set. In the future we should be using the image number.
 
       // This will be evaluated a compile time.
-      if(std::is_integral<FrameType>::value) {
+      if (std::is_integral<FrameType>::value) {
         samples[i * numberOfPixels + j] =
           blockData[randomFrameIndex * numberOfPixels + j] -
           static_cast<int16_t>(darkReference[j]);
@@ -191,16 +189,17 @@ CalculateThresholdsResults<FrameType> calculateThresholds(std::vector<BlockType>
   return ret;
 }
 
-
 // Without gain
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
   std::vector<BlockType>& blocks, Image<double>& darkreference,
   int numberOfSamples, double backgroundThresholdNSigma,
-  double xRayThresholdNSigma) {
-    return calculateThresholds<BlockType, uint16_t>(blocks, darkreference.data.get(),
-      nullptr, numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
-  }
+  double xRayThresholdNSigma)
+{
+  return calculateThresholds<BlockType, uint16_t>(
+    blocks, darkreference.data.get(), nullptr, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma);
+}
 
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
@@ -208,8 +207,9 @@ CalculateThresholdsResults<uint16_t> calculateThresholds(
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma)
 {
-    return calculateThresholds<BlockType, uint16_t>(blocks, darkreference, nullptr,
-        numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
+  return calculateThresholds<BlockType, uint16_t>(
+    blocks, darkreference, nullptr, numberOfSamples, backgroundThresholdNSigma,
+    xRayThresholdNSigma);
 }
 
 // With gain
@@ -219,35 +219,38 @@ CalculateThresholdsResults<float> calculateThresholds(
   const float gain[], int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma)
 {
-    return calculateThresholds<BlockType, float>(blocks, darkreference.data.get(),
-      gain, numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
+  return calculateThresholds<BlockType, float>(
+    blocks, darkreference.data.get(), gain, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma);
 }
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
   std::vector<BlockType>& blocks, const double darkreference[],
   const float gain[], int numberOfSamples, double backgroundThresholdNSigma,
-  double xRayThresholdNSigma) {
-    return calculateThresholds<BlockType, float>(blocks, darkreference,
-      gain, numberOfSamples, backgroundThresholdNSigma, xRayThresholdNSigma);
-  }
-
-
+  double xRayThresholdNSigma)
+{
+  return calculateThresholds<BlockType, float>(
+    blocks, darkreference, gain, numberOfSamples, backgroundThresholdNSigma,
+    xRayThresholdNSigma);
+}
 
 // With gain
 template CalculateThresholdsResults<float> calculateThresholds<Block>(
-  std::vector<Block>& blocks, Image<double>& darkReference, const float gain[], int numberOfSamples,
-  double backgroundThresholdNSigma, double xRayThresholdNSigma);
-template CalculateThresholdsResults<float> calculateThresholds<PyBlock>(
-  std::vector<PyBlock>& blocks, Image<double>& darkReference, const float gain[],
+  std::vector<Block>& blocks, Image<double>& darkReference, const float gain[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
-template CalculateThresholdsResults<float> calculateThresholds<Block>(
-  std::vector<Block>& blocks, const double darkReference[], const float gain[], int numberOfSamples,
-  double backgroundThresholdNSigma, double xRayThresholdNSigma);
 template CalculateThresholdsResults<float> calculateThresholds<PyBlock>(
-  std::vector<PyBlock>& blocks, const double darkReference[], const float gain[],
+  std::vector<PyBlock>& blocks, Image<double>& darkReference,
+  const float gain[], int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma);
+template CalculateThresholdsResults<float> calculateThresholds<Block>(
+  std::vector<Block>& blocks, const double darkReference[], const float gain[],
   int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma);
+template CalculateThresholdsResults<float> calculateThresholds<PyBlock>(
+  std::vector<PyBlock>& blocks, const double darkReference[],
+  const float gain[], int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
 
 // No gain

--- a/stempy/electronthresholds.h
+++ b/stempy/electronthresholds.h
@@ -11,13 +11,14 @@ namespace py = pybind11;
 
 namespace stempy {
 
+template<typename FrameType>
 struct CalculateThresholdsResults
 {
   double backgroundThreshold = 0.0;
   double xRayThreshold = 0.0;
   int numberOfSamples = 0;
-  int16_t minSample = 0;
-  int16_t maxSample = 0;
+  FrameType minSample = 0;
+  FrameType maxSample = 0;
   double mean = 0.0;
   double variance = 0.0;
   double stdDev = 0.0;
@@ -28,23 +29,45 @@ struct CalculateThresholdsResults
   double optimizedStdDev = 0.0;
 };
 
+// Without gain
 template <typename BlockType>
-CalculateThresholdsResults calculateThresholds(
+CalculateThresholdsResults<uint16_t> calculateThresholds(
   std::vector<BlockType>& blocks, Image<double>& darkreference,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10);
 
 template <typename BlockType>
-CalculateThresholdsResults calculateThresholds(
+CalculateThresholdsResults<uint16_t> calculateThresholds(
   std::vector<BlockType>& blocks, const double darkreference[],
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10);
 
 template <typename BlockType>
-CalculateThresholdsResults calculateThresholds(
+CalculateThresholdsResults<uint16_t> calculateThresholds(
   std::vector<BlockType>& blocks, py::array_t<double> darkreference,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10);
+
+// With gain
+template <typename BlockType>
+CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<BlockType>& blocks, Image<double>& darkreference,
+  const float gain[], int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10);
+
+template <typename BlockType>
+CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<BlockType>& blocks, const double darkreference[],
+  const float gain[],   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10);
+
+template <typename BlockType>
+CalculateThresholdsResults<float> calculateThresholds(
+  std::vector<BlockType>& blocks, py::array_t<double> darkreference,
+  const float gain[], int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10);
+
+
 }
 
 #endif /* STEMPY_ELECTRONTHRESHOLDS_H_ */

--- a/stempy/electronthresholds.h
+++ b/stempy/electronthresholds.h
@@ -11,7 +11,7 @@ namespace py = pybind11;
 
 namespace stempy {
 
-template<typename FrameType>
+template <typename FrameType>
 struct CalculateThresholdsResults
 {
   double backgroundThreshold = 0.0;
@@ -52,22 +52,20 @@ CalculateThresholdsResults<uint16_t> calculateThresholds(
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
   std::vector<BlockType>& blocks, Image<double>& darkreference,
-  const float gain[], int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10);
+  const float gain[], int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10);
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
   std::vector<BlockType>& blocks, const double darkreference[],
-  const float gain[],   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10);
+  const float gain[], int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10);
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
   std::vector<BlockType>& blocks, py::array_t<double> darkreference,
-  const float gain[], int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10);
-
-
+  const float gain[], int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10);
 }
 
 #endif /* STEMPY_ELECTRONTHRESHOLDS_H_ */

--- a/stempy/electronthresholds.h
+++ b/stempy/electronthresholds.h
@@ -29,6 +29,12 @@ struct CalculateThresholdsResults
   double optimizedStdDev = 0.0;
 };
 
+template <typename BlockType, typename FrameType>
+CalculateThresholdsResults<FrameType> calculateThresholds(
+  std::vector<BlockType>& blocks, const double darkreference[],
+  const float gain[], int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10);
+
 // Without gain
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -783,7 +783,6 @@ bool SectorStreamThreadedReader::nextSectorStreamPair(
   }
 
   auto& stream = sectorStreamPair.first;
-  auto sector = sectorStreamPair.second;
 
   auto c = stream->peek();
   // If we have reached the end close the stream and remove if from

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -269,7 +269,7 @@ public:
                              uint8_t version = 5, int threads = 0);
 
   template <typename Functor>
-  std::future<void> readAll(Functor f);
+  std::future<void> readAll(Functor& f);
 
 private:
   // The number of threads to use
@@ -305,7 +305,7 @@ private:
 };
 
 template <typename Functor>
-std::future<void> SectorStreamThreadedReader::readAll(Functor func)
+std::future<void> SectorStreamThreadedReader::readAll(Functor& func)
 {
   m_pool = std::make_unique<ThreadPool>(m_threads);
 

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -320,7 +320,6 @@ std::future<void> SectorStreamThreadedReader::readAll(Functor& func)
   // Create worker threads
   for (int i = 0; i < m_threads; i++) {
     m_futures.emplace_back(m_pool->enqueue([this, &func]() {
-      std::ifstream* close = nullptr;
 
       while (!m_streams.empty()) {
         // Get the next stream to read from
@@ -334,8 +333,8 @@ std::future<void> SectorStreamThreadedReader::readAll(Functor& func)
         // First read the header
         auto header = readHeader(*stream);
 
-        for (unsigned i = 0; i < header.imagesInBlock; i++) {
-          auto pos = header.imageNumbers[i];
+        for (unsigned j = 0; j < header.imagesInBlock; j++) {
+          auto pos = header.imageNumbers[j];
 
           std::unique_lock<std::mutex> mutexLock(m_cacheMutex);
           auto& frame = m_frameCache[pos];


### PR DESCRIPTION
This PR adds support for providing a gain mask that will be applied to each frame before electron counting is performed. For example:

```python
gain = np.ndarray((576,576), dtype=np.float32)
gain.fill( 0.5 )
ec = stim.electron_count(
  reader, 
  dark, 
  number_of_samples=1200, 
  verbose=True, 
  threshold_num_blocks=20, 
  xray_threshold_n_sigma=175, 
  background_threshold_n_sigma=threshold, 
  gain=gain
)
```

Not that this had been implement using templates, so the penalty of using floats only applies if a gain is provided.

I have pushed an image built from the PR for testing:

```openchemistry/stempy:gain```