### PR TITLE
Bump version of ipympl

### DIFF
--- a/docker/Dockerfile.ipykernel
+++ b/docker/Dockerfile.ipykernel
@@ -2,5 +2,5 @@ FROM openchemistry/stempy:latest
 
 # Note these are the specfic versions needed to work with the jupyterlab
 # deployment at NERSC, update with care!
-RUN pip3 install -U ipykernel==5.1.2 ipympl==0.4.1 matplotlib==3.1.1
+RUN pip3 install -U ipykernel==5.1.2 ipympl==0.5.6 matplotlib==3.1.1
 


### PR DESCRIPTION
Bump version of ipympl to be compatible with new JupyterLab deployment
at NERSC.