### PR TITLE
Use 32-bit floats for dark reference type

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -20,7 +20,7 @@ namespace stempy {
 
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<BlockType>& blocks, py::array_t<double> darkReference,
+  std::vector<BlockType>& blocks, py::array_t<float> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma)
 {
@@ -30,7 +30,7 @@ CalculateThresholdsResults<uint16_t> calculateThresholds(
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<BlockType>& blocks, py::array_t<double> darkReference,
+  std::vector<BlockType>& blocks, py::array_t<float> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, py::array_t<float> gain)
 {
@@ -41,7 +41,7 @@ CalculateThresholdsResults<float> calculateThresholds(
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<BlockType>& blocks, Image<double>& darkReference,
+  std::vector<BlockType>& blocks, Image<float>& darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, py::array_t<float> gain)
 {
@@ -65,27 +65,27 @@ CalculateThresholdsResults<float> calculateThresholds(
 
 // Only dark reference
 template CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<Block>& blocks, py::array_t<double> darkReference,
+  std::vector<Block>& blocks, py::array_t<float> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
 template CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<PyBlock>& blocks, py::array_t<double> darkReference,
+  std::vector<PyBlock>& blocks, py::array_t<float> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
 
 // Gain and darkreference
 template CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<Block>& blocks, py::array_t<double> darkReference,
+  std::vector<Block>& blocks, py::array_t<float> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, py::array_t<float> gain);
 template CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<PyBlock>& blocks, py::array_t<double> darkReference,
+  std::vector<PyBlock>& blocks, py::array_t<float> darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, py::array_t<float> gain);
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  py::array_t<double> darkReference,
+                                  py::array_t<float> darkReference,
                                   double backgroundThreshold,
                                   double xRayThreshold, py::array_t<float> gain,
                                   Dimensions2D scanDimensions = { 0, 0 })
@@ -96,7 +96,7 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<double>& darkReference,
+                                  Image<float>& darkReference,
                                   double backgroundThreshold,
                                   double xRayThreshold, py::array_t<float> gain,
                                   Dimensions2D scanDimensions = { 0, 0 })
@@ -107,7 +107,7 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  py::array_t<double> darkReference,
+                                  py::array_t<float> darkReference,
                                   double backgroundThreshold,
                                   double xRayThreshold,
                                   Dimensions2D scanDimensions = { 0, 0 })
@@ -127,7 +127,7 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 }
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, py::array_t<double> darkReference,
+  SectorStreamThreadedReader* reader, py::array_t<float> darkReference,
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   py::array_t<float> gain, Dimensions2D scanDimensions, bool verbose)
@@ -139,7 +139,7 @@ ElectronCountedData electronCount(
 }
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, Image<double>& darkReference,
+  SectorStreamThreadedReader* reader, Image<float>& darkReference,
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   py::array_t<float> gain, Dimensions2D scanDimensions, bool verbose)
@@ -164,7 +164,7 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
 }
 
 ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
-                                  py::array_t<double> darkReference,
+                                  py::array_t<float> darkReference,
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
                                   double backgroundThresholdNSigma,
@@ -364,50 +364,50 @@ PYBIND11_MODULE(_image, m)
   // Electron counting with gain and dark reference
   m.def("electron_count",
         (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
-                                Image<double>&, double, double,
+                                Image<float>&, double, double,
                                 py::array_t<float>, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(
           SectorStreamReader::iterator, SectorStreamReader::iterator,
-          Image<double>&, double, double, py::array_t<float>, Dimensions2D)) &
+          Image<float>&, double, double, py::array_t<float>, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
-                                Image<double>&, double, double,
+                                Image<float>&, double, double,
                                 py::array_t<float>, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
-                                py::array_t<double>, double, double,
+                                py::array_t<float>, double, double,
                                 py::array_t<float>, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def(
     "electron_count",
     (ElectronCountedData(*)(SectorStreamReader::iterator,
-                            SectorStreamReader::iterator, py::array_t<double>,
+                            SectorStreamReader::iterator, py::array_t<float>,
                             double, double, py::array_t<float>, Dimensions2D)) &
       electronCount,
     py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
-                                py::array_t<double>, double, double,
+                                py::array_t<float>, double, double,
                                 py::array_t<float>, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<double>&,
+        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<float>&,
                                 int, int, double, double, py::array_t<float>,
                                 Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(SectorStreamThreadedReader*,
-                                py::array_t<double>, int, int, double, double,
+                                py::array_t<float>, int, int, double, double,
                                 py::array_t<float>, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
@@ -420,40 +420,40 @@ PYBIND11_MODULE(_image, m)
   // Electron counting, without gain
   m.def("electron_count",
         (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
-                                Image<double>&, double, double, Dimensions2D)) &
+                                Image<float>&, double, double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(SectorStreamReader::iterator,
-                                SectorStreamReader::iterator, Image<double>&,
+                                SectorStreamReader::iterator, Image<float>&,
                                 double, double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
-                                Image<double>&, double, double, Dimensions2D)) &
+                                Image<float>&, double, double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
-                                py::array_t<double>, double, double,
+                                py::array_t<float>, double, double,
                                 Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(
           SectorStreamReader::iterator, SectorStreamReader::iterator,
-          py::array_t<double>, double, double, Dimensions2D)) &
+          py::array_t<float>, double, double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
-                                py::array_t<double>, double, double,
+                                py::array_t<float>, double, double,
                                 Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<double>&,
+        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<float>&,
                                 int, int, double, double, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
@@ -464,7 +464,7 @@ PYBIND11_MODULE(_image, m)
         py::call_guard<py::gil_scoped_release>());
   m.def(
     "electron_count",
-    (ElectronCountedData(*)(SectorStreamThreadedReader*, py::array_t<double>,
+    (ElectronCountedData(*)(SectorStreamThreadedReader*, py::array_t<float>,
                             int, int, double, double, Dimensions2D, bool)) &
       electronCount,
     py::call_guard<py::gil_scoped_release>());
@@ -490,48 +490,48 @@ PYBIND11_MODULE(_image, m)
   // Calculate thresholds, with gain
   m.def(
     "calculate_thresholds",
-    (CalculateThresholdsResults<float>(*)(vector<Block>&, Image<double>&, int,
+    (CalculateThresholdsResults<float>(*)(vector<Block>&, Image<float>&, int,
                                           double, double, py::array_t<float>)) &
       calculateThresholds,
     py::call_guard<py::gil_scoped_release>());
   m.def(
     "calculate_thresholds",
-    (CalculateThresholdsResults<float>(*)(vector<PyBlock>&, Image<double>&, int,
+    (CalculateThresholdsResults<float>(*)(vector<PyBlock>&, Image<float>&, int,
                                           double, double, py::array_t<float>)) &
       calculateThresholds,
     py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
         (CalculateThresholdsResults<float>(*)(vector<Block>&,
-                                              py::array_t<double>, int, double,
+                                              py::array_t<float>, int, double,
                                               double, py::array_t<float>)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
         (CalculateThresholdsResults<float>(*)(vector<PyBlock>&,
-                                              py::array_t<double>, int, double,
+                                              py::array_t<float>, int, double,
                                               double, py::array_t<float>)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
 
   // Calculate thresholds, without gain
   m.def("calculate_thresholds",
-        (CalculateThresholdsResults<uint16_t>(*)(vector<Block>&, Image<double>&,
+        (CalculateThresholdsResults<uint16_t>(*)(vector<Block>&, Image<float>&,
                                                  int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
         (CalculateThresholdsResults<uint16_t>(*)(
-          vector<PyBlock>&, Image<double>&, int, double, double)) &
+          vector<PyBlock>&, Image<float>&, int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
         (CalculateThresholdsResults<uint16_t>(*)(
-          vector<Block>&, py::array_t<double>, int, double, double)) &
+          vector<Block>&, py::array_t<float>, int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
   m.def("calculate_thresholds",
         (CalculateThresholdsResults<uint16_t>(*)(
-          vector<PyBlock>&, py::array_t<double>, int, double, double)) &
+          vector<PyBlock>&, py::array_t<float>, int, double, double)) &
           calculateThresholds,
         py::call_guard<py::gil_scoped_release>());
 
@@ -587,7 +587,7 @@ PYBIND11_MODULE(_image, m)
         py::call_guard<py::gil_scoped_release>());
   m.def("maximum_diffraction_pattern",
         (Image<double>(*)(StreamReader::iterator, StreamReader::iterator,
-                          const Image<double>&)) &
+                          const Image<float>&)) &
           maximumDiffractionPattern<StreamReader::iterator>,
         py::call_guard<py::gil_scoped_release>());
   m.def("maximum_diffraction_pattern",
@@ -596,7 +596,7 @@ PYBIND11_MODULE(_image, m)
         py::call_guard<py::gil_scoped_release>());
   m.def("maximum_diffraction_pattern",
         (Image<double>(*)(SectorStreamReader::iterator,
-                          SectorStreamReader::iterator, const Image<double>&)) &
+                          SectorStreamReader::iterator, const Image<float>&)) &
           maximumDiffractionPattern<SectorStreamReader::iterator>,
         py::call_guard<py::gil_scoped_release>());
   m.def("maximum_diffraction_pattern",

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -400,15 +400,15 @@ PYBIND11_MODULE(_image, m)
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<float>&,
-                                int, int, double, double, py::array_t<float>,
+        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<float>&, int,
+                                int, double, double, py::array_t<float>,
                                 Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        (ElectronCountedData(*)(SectorStreamThreadedReader*,
-                                py::array_t<float>, int, int, double, double,
-                                py::array_t<float>, Dimensions2D, bool)) &
+        (ElectronCountedData(*)(SectorStreamThreadedReader*, py::array_t<float>,
+                                int, int, double, double, py::array_t<float>,
+                                Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
@@ -434,27 +434,27 @@ PYBIND11_MODULE(_image, m)
                                 Image<float>&, double, double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
-  m.def("electron_count",
-        (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
-                                py::array_t<float>, double, double,
-                                Dimensions2D)) &
-          electronCount,
-        py::call_guard<py::gil_scoped_release>());
+  m.def(
+    "electron_count",
+    (ElectronCountedData(*)(StreamReader::iterator, StreamReader::iterator,
+                            py::array_t<float>, double, double, Dimensions2D)) &
+      electronCount,
+    py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedData(*)(
           SectorStreamReader::iterator, SectorStreamReader::iterator,
           py::array_t<float>, double, double, Dimensions2D)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
+  m.def(
+    "electron_count",
+    (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
+                            py::array_t<float>, double, double, Dimensions2D)) &
+      electronCount,
+    py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        (ElectronCountedData(*)(PyReader::iterator, PyReader::iterator,
-                                py::array_t<float>, double, double,
-                                Dimensions2D)) &
-          electronCount,
-        py::call_guard<py::gil_scoped_release>());
-  m.def("electron_count",
-        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<float>&,
-                                int, int, double, double, Dimensions2D, bool)) &
+        (ElectronCountedData(*)(SectorStreamThreadedReader*, Image<float>&, int,
+                                int, double, double, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
@@ -462,12 +462,11 @@ PYBIND11_MODULE(_image, m)
                                 double, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
-  m.def(
-    "electron_count",
-    (ElectronCountedData(*)(SectorStreamThreadedReader*, py::array_t<float>,
-                            int, int, double, double, Dimensions2D, bool)) &
-      electronCount,
-    py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedData(*)(SectorStreamThreadedReader*, py::array_t<float>,
+                                int, int, double, double, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
 
   // Electron counting without dark reference or gain
   m.def("electron_count",
@@ -605,8 +604,7 @@ PYBIND11_MODULE(_image, m)
           maximumDiffractionPattern<SectorStreamReader::iterator>,
         py::call_guard<py::gil_scoped_release>());
   m.def("maximum_diffraction_pattern",
-        (Image<double>(*)(PyReader::iterator,
-                          PyReader::iterator)) &
+        (Image<double>(*)(PyReader::iterator, PyReader::iterator)) &
           maximumDiffractionPattern<PyReader::iterator>,
         py::call_guard<py::gil_scoped_release>());
 }

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -317,8 +317,13 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
             'scan_dimensions', and 'frame_dimensions')
     """
     if gain is not None:
-        # Invert as we will multiple in C++
-        gain = np.power(gain, -1)
+        # Invert, as we will multiply in C++
+        # It also must be a float32
+        gain = np.power(gain, -1).astype(np.float32)
+
+    if isinstance(darkreference, np.ndarray):
+        # Must be float32 for correct conversions
+        darkreference = darkreference.astype(np.float32)
 
     # Special case for threaded reader
     if isinstance(reader, SectorThreadedReader):

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -319,11 +319,12 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
     if gain is not None:
         # Invert, as we will multiply in C++
         # It also must be a float32
-        gain = np.power(gain, -1).astype(np.float32)
+        gain = np.power(gain, -1)
+        gain = _safe_convert(gain, np.float32)
 
     if isinstance(darkreference, np.ndarray):
         # Must be float32 for correct conversions
-        darkreference = darkreference.astype(np.float32)
+        darkreference = _safe_convert(darkreference, np.float32)
 
     # Special case for threaded reader
     if isinstance(reader, SectorThreadedReader):
@@ -567,3 +568,13 @@ def radial_sum_sparse(electron_counts, scan_dimensions, frame_dimensions,
     r_sum = r_sum.reshape((scan_dimensions[0], scan_dimensions[1], num_bins))
 
     return r_sum
+
+
+def _safe_convert(array, dtype):
+    # Convert the array to a different dtype, ensuring no loss of
+    # precision. Otherwise, an exception will be raised.
+    new_array = array.astype(dtype)
+    if np.any(new_array.astype(array.dtype) != array):
+        msg = f'Cannot convert array to {dtype} without loss of precision'
+        raise ValueError(msg)
+    return new_array

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -320,11 +320,11 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         # Invert, as we will multiply in C++
         # It also must be a float32
         gain = np.power(gain, -1)
-        gain = _safe_convert(gain, np.float32)
+        gain = _safe_cast(gain, np.float32, 'gain')
 
     if isinstance(darkreference, np.ndarray):
         # Must be float32 for correct conversions
-        darkreference = _safe_convert(darkreference, np.float32)
+        darkreference = _safe_cast(darkreference, np.float32, 'dark reference')
 
     # Special case for threaded reader
     if isinstance(reader, SectorThreadedReader):
@@ -570,11 +570,14 @@ def radial_sum_sparse(electron_counts, scan_dimensions, frame_dimensions,
     return r_sum
 
 
-def _safe_convert(array, dtype):
-    # Convert the array to a different dtype, ensuring no loss of
+def _safe_cast(array, dtype, name=None):
+    # Cast the array to a different dtype, ensuring no loss of
     # precision. Otherwise, an exception will be raised.
+    if name is None:
+        name = 'array'
+
     new_array = array.astype(dtype)
     if np.any(new_array.astype(array.dtype) != array):
-        msg = f'Cannot convert array to {dtype} without loss of precision'
+        msg = f'Cannot cast {name} to {dtype} without loss of precision'
         raise ValueError(msg)
     return new_array

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -156,7 +156,7 @@ private:
 template <typename FrameType, bool dark = true>
 std::vector<uint32_t> maximalPointsParallel(std::vector<FrameType>& frame,
                                             Dimensions2D frameDimensions,
-                                            const double* darkReferenceData,
+                                            const float* darkReferenceData,
                                             const float* gain,
                                             double backgroundThreshold,
                                             double xRayThreshold)
@@ -314,7 +314,7 @@ std::vector<uint32_t> maximalPoints(const std::vector<FrameType>& frame,
 
 template <typename InputIt, typename FrameType, bool dark = true>
 ElectronCountedData electronCount(
-  InputIt first, InputIt last, const double darkReference[], const float gain[],
+  InputIt first, InputIt last, const float darkReference[], const float gain[],
   double backgroundThreshold, double xRayThreshold, Dimensions2D scanDimensions)
 {
   if (first == last) {
@@ -388,7 +388,7 @@ ElectronCountedData electronCount(
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const double darkReference[],
+                                  const float darkReference[],
                                   double backgroundThreshold,
                                   double xRayThreshold,
                                   Dimensions2D scanDimensions)
@@ -400,7 +400,7 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const double darkReference[],
+                                  const float darkReference[],
                                   double backgroundThreshold,
                                   double xRayThreshold, const float gain[],
                                   Dimensions2D scanDimensions)
@@ -412,7 +412,7 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<double>& darkReference,
+                                  Image<float>& darkReference,
                                   double backgroundThreshold,
                                   double xRayThreshold, const float gain[],
                                   Dimensions2D scanDimensions)
@@ -424,7 +424,7 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<double>& darkReference,
+                                  Image<float>& darkReference,
                                   double backgroundThreshold,
                                   double xRayThreshold,
                                   Dimensions2D scanDimensions)
@@ -459,7 +459,7 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
 template <typename FrameType, bool dark = true>
 std::vector<uint32_t> electronCount(std::vector<FrameType>& frame,
                                     Dimensions2D frameDimensions,
-                                    const double darkReference[],
+                                    const float darkReference[],
                                     double backgroundThreshold,
                                     double xRayThreshold, const float gain[])
 {
@@ -487,7 +487,7 @@ std::vector<uint32_t> electronCount(std::vector<FrameType>& frame,
 
 std::vector<uint32_t> electronCount(std::vector<uint16_t>& frame,
                                     Dimensions2D frameDimensions,
-                                    const double darkReference[],
+                                    const float darkReference[],
                                     double backgroundThreshold,
                                     double xRayThreshold)
 {
@@ -497,7 +497,7 @@ std::vector<uint32_t> electronCount(std::vector<uint16_t>& frame,
 
 std::vector<uint32_t> electronCount(std::vector<float>& frame,
                                     Dimensions2D frameDimensions,
-                                    const double darkReference[],
+                                    const float darkReference[],
                                     double backgroundThreshold,
                                     double xRayThreshold, const float gain[])
 {
@@ -507,7 +507,7 @@ std::vector<uint32_t> electronCount(std::vector<float>& frame,
 
 template <typename FrameType, bool dark = true>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const double darkReference[],
+  SectorStreamThreadedReader* reader, const float darkReference[],
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[], Dimensions2D scanDimensions, bool verbose)
@@ -668,7 +668,7 @@ ElectronCountedData electronCount(
 }
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const double darkReference[],
+  SectorStreamThreadedReader* reader, const float darkReference[],
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[], Dimensions2D scanDimensions, bool verbose)
@@ -680,7 +680,7 @@ ElectronCountedData electronCount(
 }
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, Image<double>& darkReference,
+  SectorStreamThreadedReader* reader, Image<float>& darkReference,
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[], Dimensions2D scanDimensions, bool verbose)
@@ -692,7 +692,7 @@ ElectronCountedData electronCount(
 }
 
 ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
-                                  const double darkReference[],
+                                  const float darkReference[],
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
                                   double backgroundThresholdNSigma,
@@ -706,7 +706,7 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
 }
 
 ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
-                                  Image<double>& darkReference,
+                                  Image<float>& darkReference,
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
                                   double backgroundThresholdNSigma,
@@ -751,63 +751,63 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
 // With gain and dark reference
 template ElectronCountedData electronCount(
   StreamReader::iterator first, StreamReader::iterator last,
-  Image<double>& darkReference, double backgroundThreshold,
+  Image<float>& darkReference, double backgroundThreshold,
   double xRayThreshold, const float gain[], Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(
   StreamReader::iterator first, StreamReader::iterator last,
-  const double darkReference[], double backgroundThreshold,
+  const float darkReference[], double backgroundThreshold,
   double xRayThreshold, const float gain[], Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(
   SectorStreamReader::iterator first, SectorStreamReader::iterator last,
-  Image<double>& darkReference, double backgroundThreshold,
+  Image<float>& darkReference, double backgroundThreshold,
   double xRayThreshold, const float gain[], Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(
   SectorStreamReader::iterator first, SectorStreamReader::iterator last,
-  const double darkReference[], double backgroundThreshold,
+  const float darkReference[], double backgroundThreshold,
   double xRayThreshold, const float gain[], Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(
   PyReader::iterator first, PyReader::iterator last,
-  Image<double>& darkReference, double backgroundThreshold,
+  Image<float>& darkReference, double backgroundThreshold,
   double xRayThreshold, const float gain[], Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(
   PyReader::iterator first, PyReader::iterator last,
-  const double darkReference[], double backgroundThreshold,
+  const float darkReference[], double backgroundThreshold,
   double xRayThreshold, const float gain[], Dimensions2D scanDimensions);
 
 // Without gain and with dark reference
 template ElectronCountedData electronCount(StreamReader::iterator first,
                                            StreamReader::iterator last,
-                                           Image<double>& darkReference,
+                                           Image<float>& darkReference,
                                            double backgroundThreshold,
                                            double xRayThreshold,
                                            Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(StreamReader::iterator first,
                                            StreamReader::iterator last,
-                                           const double darkReference[],
+                                           const float darkReference[],
                                            double backgroundThreshold,
                                            double xRayThreshold,
                                            Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(SectorStreamReader::iterator first,
                                            SectorStreamReader::iterator last,
-                                           Image<double>& darkReference,
+                                           Image<float>& darkReference,
                                            double backgroundThreshold,
                                            double xRayThreshold,
                                            Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(SectorStreamReader::iterator first,
                                            SectorStreamReader::iterator last,
-                                           const double darkReference[],
+                                           const float darkReference[],
                                            const double backgroundThreshold,
                                            double xRayThreshold,
                                            Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(PyReader::iterator first,
                                            PyReader::iterator last,
-                                           Image<double>& darkReference,
+                                           Image<float>& darkReference,
                                            double backgroundThreshold,
                                            double xRayThreshold,
                                            Dimensions2D scanDimensions);
 template ElectronCountedData electronCount(PyReader::iterator first,
                                            PyReader::iterator last,
-                                           const double darkReference[],
+                                           const float darkReference[],
                                            double backgroundThreshold,
                                            double xRayThreshold,
                                            Dimensions2D scanDimensions);

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -17,28 +17,28 @@ struct ElectronCountedData
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<double>& darkreference,
+                                  Image<float>& darkreference,
                                   double backgroundThreshold,
                                   double xRayThreshold,
                                   Dimensions2D scanDimensions = { 0, 0 });
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const double darkreference[],
+                                  const float darkreference[],
                                   double backgroundThreshold,
                                   double xRayThreshold,
                                   Dimensions2D scanDimensions = { 0, 0 });
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<double>& darkreference,
+                                  Image<float>& darkreference,
                                   double backgroundThreshold,
                                   double xRayThreshold, const float gain[],
                                   Dimensions2D scanDimensions = { 0, 0 });
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const double darkreference[],
+                                  const float darkreference[],
                                   double backgroundThreshold,
                                   double xRayThreshold, const float gain[],
                                   Dimensions2D scanDimensions = { 0, 0 });
@@ -56,26 +56,26 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
                                   Dimensions2D scanDimensions = { 0, 0 });
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, Image<double>& darkreference,
+  SectorStreamThreadedReader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const double darkreference[],
+  SectorStreamThreadedReader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, Image<double>& darkreference,
+  SectorStreamThreadedReader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const double darkreference[],
+  SectorStreamThreadedReader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -73,7 +73,7 @@ struct GaussianErrorFunctor : Eigen::DenseFunctor<double>
 
 template <typename BlockType, typename FrameType, bool dark>
 CalculateThresholdsResults<FrameType> calculateThresholds(
-  std::vector<BlockType>& blocks, const double darkReference[],
+  std::vector<BlockType>& blocks, const float darkReference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[])
 {
@@ -194,7 +194,7 @@ CalculateThresholdsResults<FrameType> calculateThresholds(
 // Without gain
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<BlockType>& blocks, Image<double>& darkreference,
+  std::vector<BlockType>& blocks, Image<float>& darkreference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma)
 {
@@ -205,7 +205,7 @@ CalculateThresholdsResults<uint16_t> calculateThresholds(
 
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<BlockType>& blocks, const double darkreference[],
+  std::vector<BlockType>& blocks, const float darkreference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma)
 {
@@ -217,7 +217,7 @@ CalculateThresholdsResults<uint16_t> calculateThresholds(
 // With gain
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<BlockType>& blocks, Image<double>& darkreference,
+  std::vector<BlockType>& blocks, Image<float>& darkreference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[])
 {
@@ -228,7 +228,7 @@ CalculateThresholdsResults<float> calculateThresholds(
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<BlockType>& blocks, const double darkreference[],
+  std::vector<BlockType>& blocks, const float darkreference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[])
 {
@@ -250,48 +250,48 @@ CalculateThresholdsResults<uint16_t> calculateThresholds(
 
 // With gain
 template CalculateThresholdsResults<float> calculateThresholds<Block>(
-  std::vector<Block>& blocks, Image<double>& darkReference, int numberOfSamples,
+  std::vector<Block>& blocks, Image<float>& darkReference, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[]);
 template CalculateThresholdsResults<float> calculateThresholds<PyBlock>(
-  std::vector<PyBlock>& blocks, Image<double>& darkReference,
+  std::vector<PyBlock>& blocks, Image<float>& darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[]);
 template CalculateThresholdsResults<float> calculateThresholds<Block>(
-  std::vector<Block>& blocks, const double darkReference[], int numberOfSamples,
+  std::vector<Block>& blocks, const float darkReference[], int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[]);
 template CalculateThresholdsResults<float> calculateThresholds<PyBlock>(
-  std::vector<PyBlock>& blocks, const double darkReference[],
+  std::vector<PyBlock>& blocks, const float darkReference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[]);
 
 // No gain
 template CalculateThresholdsResults<uint16_t> calculateThresholds<Block>(
-  std::vector<Block>& blocks, Image<double>& darkReference, int numberOfSamples,
+  std::vector<Block>& blocks, Image<float>& darkReference, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma);
 template CalculateThresholdsResults<uint16_t> calculateThresholds<PyBlock>(
-  std::vector<PyBlock>& blocks, Image<double>& darkReference,
+  std::vector<PyBlock>& blocks, Image<float>& darkReference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
 template CalculateThresholdsResults<uint16_t> calculateThresholds<Block>(
-  std::vector<Block>& blocks, const double darkReference[], int numberOfSamples,
+  std::vector<Block>& blocks, const float darkReference[], int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma);
 template CalculateThresholdsResults<uint16_t> calculateThresholds<PyBlock>(
-  std::vector<PyBlock>& blocks, const double darkReference[],
+  std::vector<PyBlock>& blocks, const float darkReference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma);
 
 template CalculateThresholdsResults<uint16_t>
 calculateThresholds<Block, uint16_t, false>(std::vector<Block>& blocks,
-                                            const double darkReference[],
+                                            const float darkReference[],
                                             int numberOfSamples,
                                             double backgroundThresholdNSigma,
                                             double xRayThresholdNSigma,
                                             const float gain[]);
 template CalculateThresholdsResults<uint16_t>
 calculateThresholds<PyBlock, uint16_t, false>(std::vector<PyBlock>& blocks,
-                                              const double darkReference[],
+                                              const float darkReference[],
                                               int numberOfSamples,
                                               double backgroundThresholdNSigma,
                                               double xRayThresholdNSigma,
@@ -299,14 +299,14 @@ calculateThresholds<PyBlock, uint16_t, false>(std::vector<PyBlock>& blocks,
 
 template CalculateThresholdsResults<float>
 calculateThresholds<Block, float, false>(std::vector<Block>& blocks,
-                                         const double darkReference[],
+                                         const float darkReference[],
                                          int numberOfSamples,
                                          double backgroundThresholdNSigma,
                                          double xRayThresholdNSigma,
                                          const float gain[]);
 template CalculateThresholdsResults<float>
 calculateThresholds<PyBlock, float, false>(std::vector<PyBlock>& blocks,
-                                           const double darkReference[],
+                                           const float darkReference[],
                                            int numberOfSamples,
                                            double backgroundThresholdNSigma,
                                            double xRayThresholdNSigma,

--- a/stempy/electronthresholds.h
+++ b/stempy/electronthresholds.h
@@ -31,45 +31,45 @@ struct CalculateThresholdsResults
 
 template <typename BlockType, typename FrameType, bool dark = true>
 CalculateThresholdsResults<FrameType> calculateThresholds(
-  std::vector<BlockType>& blocks, const double darkreference[],
+  std::vector<BlockType>& blocks, const float darkreference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[]);
 
 // Without gain
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<BlockType>& blocks, Image<double>& darkreference,
+  std::vector<BlockType>& blocks, Image<float>& darkreference,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10);
 
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<BlockType>& blocks, const double darkreference[],
+  std::vector<BlockType>& blocks, const float darkreference[],
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10);
 
 template <typename BlockType>
 CalculateThresholdsResults<uint16_t> calculateThresholds(
-  std::vector<BlockType>& blocks, py::array_t<double> darkreference,
+  std::vector<BlockType>& blocks, py::array_t<float> darkreference,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10);
 
 // With gain
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<BlockType>& blocks, Image<double>& darkreference,
+  std::vector<BlockType>& blocks, Image<float>& darkreference,
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[]);
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<BlockType>& blocks, const double darkreference[],
+  std::vector<BlockType>& blocks, const float darkreference[],
   int numberOfSamples, double backgroundThresholdNSigma,
   double xRayThresholdNSigma, const float gain[]);
 
 template <typename BlockType>
 CalculateThresholdsResults<float> calculateThresholds(
-  std::vector<BlockType>& blocks, py::array_t<double> darkreference,
+  std::vector<BlockType>& blocks, py::array_t<float> darkreference,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10);
 

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -589,7 +589,7 @@ RadialSum<uint64_t> radialSum(InputIt first, InputIt last,
 
 template <typename InputIt>
 Image<double> maximumDiffractionPattern(InputIt first, InputIt last,
-                                        const Image<double>& darkreference)
+                                        const Image<float>& darkreference)
 {
   auto frameDimensions = first->header.frameDimensions;
   auto numDetectorPixels = frameDimensions.first * frameDimensions.second;
@@ -627,7 +627,7 @@ template <typename InputIt>
 Image<double> maximumDiffractionPattern(InputIt first, InputIt last)
 {
   // Create empty dark reference
-  Image<double> dark;
+  Image<float> dark;
 
   return maximumDiffractionPattern(first, last, dark);
 }
@@ -681,16 +681,16 @@ template RadialSum<uint64_t> radialSum(PyReader::iterator first,
 
 template Image<double> maximumDiffractionPattern(
   StreamReader::iterator first, StreamReader::iterator last,
-  const Image<double>& darkreference);
+  const Image<float>& darkreference);
 template Image<double> maximumDiffractionPattern(
   vector<Block>::iterator first, vector<Block>::iterator last,
-  const Image<double>& darkreference);
+  const Image<float>& darkreference);
 template Image<double> maximumDiffractionPattern(
   SectorStreamReader::iterator first, SectorStreamReader::iterator last,
-  const Image<double>& darkreference);
+  const Image<float>& darkreference);
 template Image<double> maximumDiffractionPattern(
   PyReader::iterator first, PyReader::iterator last,
-  const Image<double>& darkreference);
+  const Image<float>& darkreference);
 template Image<double> maximumDiffractionPattern(StreamReader::iterator first,
                                                  StreamReader::iterator last);
 template Image<double> maximumDiffractionPattern(vector<Block>::iterator first,

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -134,7 +134,7 @@ namespace stempy {
 
   template <typename InputIt>
   Image<double> maximumDiffractionPattern(InputIt first, InputIt last,
-                                          const Image<double>& darkreference);
+                                          const Image<float>& darkreference);
 
   template <typename InputIt>
   Image<double> maximumDiffractionPattern(InputIt first, InputIt last);


### PR DESCRIPTION
Instead of a 64-bit double, use 32-bit floats for the dark reference
type, since 32-bit is usually big enough.

Fixes: #156