### PR TITLE
Add multi-pass reader

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -461,9 +461,9 @@ PYBIND11_MODULE(_image, m)
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        (ElectronCountedDataPyArray(*)(SectorStreamMultiPassThreadedReader*, int, int,
-                                       double, double, py::array_t<float>,
-                                       Dimensions2D, bool)) &
+        (ElectronCountedDataPyArray(*)(
+          SectorStreamMultiPassThreadedReader*, int, int, double, double,
+          py::array_t<float>, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
 
@@ -523,19 +523,19 @@ PYBIND11_MODULE(_image, m)
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedDataPyArray(*)(
-          SectorStreamMultiPassThreadedReader*, Image<float>&, int, int, double, double,
-          py::array_t<float>, Dimensions2D, bool)) &
-          electronCount,
-        py::call_guard<py::gil_scoped_release>());
-  m.def("electron_count",
-        (ElectronCountedDataPyArray(*)(
-          SectorStreamMultiPassThreadedReader*, py::array_t<float>, int, int, double,
+          SectorStreamMultiPassThreadedReader*, Image<float>&, int, int, double,
           double, py::array_t<float>, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double, double,
-                        Dimensions2D, bool>,
+        (ElectronCountedDataPyArray(*)(
+          SectorStreamMultiPassThreadedReader*, py::array_t<float>, int, int,
+          double, double, py::array_t<float>, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double,
+                        double, Dimensions2D, bool>,
         py::call_guard<py::gil_scoped_release>());
 
   // Electron counting, without gain
@@ -599,28 +599,13 @@ PYBIND11_MODULE(_image, m)
           electronCount,
         py::call_guard<py::gil_scoped_release>());
 
-
   m.def("electron_count",
-        electronCountPy<SectorStreamMultiPassThreadedReader*, Image<float>&, int, int,
-                        double, double, Dimensions2D, bool>,
+        electronCountPy<SectorStreamMultiPassThreadedReader*, Image<float>&,
+                        int, int, double, double, Dimensions2D, bool>,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
-        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double, double,
-                        Dimensions2D, bool>,
-        py::call_guard<py::gil_scoped_release>());
-  m.def("electron_count",
-        (ElectronCountedDataPyArray(*)(SectorStreamMultiPassThreadedReader*,
-                                       py::array_t<float>, int, int, double,
-                                       double, Dimensions2D, bool)) &
-          electronCount,
-        py::call_guard<py::gil_scoped_release>());
-  m.def("electron_count",
-        electronCountPy<SectorStreamMultiPassThreadedReader*, Image<float>&, int, int,
-                        double, double, Dimensions2D, bool>,
-        py::call_guard<py::gil_scoped_release>());
-  m.def("electron_count",
-        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double, double,
-                        Dimensions2D, bool>,
+        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double,
+                        double, Dimensions2D, bool>,
         py::call_guard<py::gil_scoped_release>());
   m.def("electron_count",
         (ElectronCountedDataPyArray(*)(SectorStreamMultiPassThreadedReader*,
@@ -628,7 +613,20 @@ PYBIND11_MODULE(_image, m)
                                        double, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
-
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, Image<float>&,
+                        int, int, double, double, Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double,
+                        double, Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedDataPyArray(*)(SectorStreamMultiPassThreadedReader*,
+                                       py::array_t<float>, int, int, double,
+                                       double, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
 
   // Electron counting without dark reference or gain
   m.def("electron_count",

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -205,6 +205,52 @@ ElectronCountedDataPyArray electronCount(
                        xRayThresholdNSigma, scanDimensions, verbose);
 }
 
+ElectronCountedDataPyArray electronCount(
+  SectorStreamMultiPassThreadedReader* reader, py::array_t<float> darkReference,
+  int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  py::array_t<float> gain, Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount(reader, darkReference.data(), thresholdNumberOfBlocks,
+                       numberOfSamples, backgroundThresholdNSigma,
+                       xRayThresholdNSigma, gain.data(), scanDimensions,
+                       verbose);
+}
+
+ElectronCountedDataPyArray electronCount(
+  SectorStreamMultiPassThreadedReader* reader, Image<float>& darkReference,
+  int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  py::array_t<float> gain, Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount(reader, darkReference, thresholdNumberOfBlocks,
+                       numberOfSamples, backgroundThresholdNSigma,
+                       xRayThresholdNSigma, gain.data(), scanDimensions,
+                       verbose);
+}
+
+ElectronCountedDataPyArray electronCount(
+  SectorStreamMultiPassThreadedReader* reader, int thresholdNumberOfBlocks,
+  int numberOfSamples, double backgroundThresholdNSigma,
+  double xRayThresholdNSigma, py::array_t<float> gain,
+  Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount(reader, thresholdNumberOfBlocks, numberOfSamples,
+                       backgroundThresholdNSigma, xRayThresholdNSigma,
+                       gain.data(), scanDimensions, verbose);
+}
+
+ElectronCountedDataPyArray electronCount(
+  SectorStreamMultiPassThreadedReader* reader, py::array_t<float> darkReference,
+  int thresholdNumberOfBlocks, int numberOfSamples,
+  double backgroundThresholdNSigma, double xRayThresholdNSigma,
+  Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount(reader, darkReference.data(), thresholdNumberOfBlocks,
+                       numberOfSamples, backgroundThresholdNSigma,
+                       xRayThresholdNSigma, scanDimensions, verbose);
+}
+
 // Explicitly instantiate version for py::array_t
 template std::vector<STEMImage> createSTEMImages(
   const std::vector<py::array_t<uint32_t>>& sparseData,
@@ -414,6 +460,12 @@ PYBIND11_MODULE(_image, m)
                                        Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedDataPyArray(*)(SectorStreamMultiPassThreadedReader*, int, int,
+                                       double, double, py::array_t<float>,
+                                       Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
 
   // Electron counting with gain and dark reference
   m.def("electron_count",
@@ -469,6 +521,22 @@ PYBIND11_MODULE(_image, m)
         electronCountPy<SectorStreamThreadedReader*, int, int, double, double,
                         Dimensions2D, bool>,
         py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedDataPyArray(*)(
+          SectorStreamMultiPassThreadedReader*, Image<float>&, int, int, double, double,
+          py::array_t<float>, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedDataPyArray(*)(
+          SectorStreamMultiPassThreadedReader*, py::array_t<float>, int, int, double,
+          double, py::array_t<float>, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double, double,
+                        Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
 
   // Electron counting, without gain
   m.def("electron_count",
@@ -516,6 +584,51 @@ PYBIND11_MODULE(_image, m)
                                        double, Dimensions2D, bool)) &
           electronCount,
         py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamThreadedReader*, Image<float>&, int, int,
+                        double, double, Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamThreadedReader*, int, int, double, double,
+                        Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedDataPyArray(*)(SectorStreamThreadedReader*,
+                                       py::array_t<float>, int, int, double,
+                                       double, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+
+
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, Image<float>&, int, int,
+                        double, double, Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double, double,
+                        Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedDataPyArray(*)(SectorStreamMultiPassThreadedReader*,
+                                       py::array_t<float>, int, int, double,
+                                       double, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, Image<float>&, int, int,
+                        double, double, Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        electronCountPy<SectorStreamMultiPassThreadedReader*, int, int, double, double,
+                        Dimensions2D, bool>,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("electron_count",
+        (ElectronCountedDataPyArray(*)(SectorStreamMultiPassThreadedReader*,
+                                       py::array_t<float>, int, int, double,
+                                       double, Dimensions2D, bool)) &
+          electronCount,
+        py::call_guard<py::gil_scoped_release>());
+
 
   // Electron counting without dark reference or gain
   m.def("electron_count",

--- a/python/io.cpp
+++ b/python/io.cpp
@@ -116,4 +116,10 @@ PYBIND11_MODULE(_io, m)
          py::arg("version") = 5, py::arg("threads") = 0)
     .def(py::init<const std::vector<std::string>&, uint8_t, int>(),
          py::arg("files"), py::arg("version") = 5, py::arg("threads") = 0);
+  py::class_<SectorStreamMultiPassThreadedReader>(m, "_threaded_multi_pass_reader")
+    .def(py::init<const std::string&, int>(), py::arg("path"),
+         py::arg("threads") = 0)
+    .def(py::init<const std::vector<std::string>&, int>(),
+         py::arg("files"), py::arg("threads") = 0);
+
 }

--- a/python/io.cpp
+++ b/python/io.cpp
@@ -116,10 +116,10 @@ PYBIND11_MODULE(_io, m)
          py::arg("version") = 5, py::arg("threads") = 0)
     .def(py::init<const std::vector<std::string>&, uint8_t, int>(),
          py::arg("files"), py::arg("version") = 5, py::arg("threads") = 0);
-  py::class_<SectorStreamMultiPassThreadedReader>(m, "_threaded_multi_pass_reader")
+  py::class_<SectorStreamMultiPassThreadedReader>(m,
+                                                  "_threaded_multi_pass_reader")
     .def(py::init<const std::string&, int>(), py::arg("path"),
          py::arg("threads") = 0)
-    .def(py::init<const std::vector<std::string>&, int>(),
-         py::arg("files"), py::arg("threads") = 0);
-
+    .def(py::init<const std::vector<std::string>&, int>(), py::arg("files"),
+         py::arg("threads") = 0);
 }

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -1,6 +1,9 @@
 from stempy import _image
 from stempy import _io
-from stempy.io import get_hdf5_reader, ReaderMixin, PyReader, SectorThreadedReader
+from stempy.io import (
+    get_hdf5_reader, ReaderMixin, PyReader, SectorThreadedReader,
+    SectorThreadedMultiPassReader
+)
 
 from collections import namedtuple
 import deprecation
@@ -327,7 +330,7 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         darkreference = _safe_cast(darkreference, np.float32, 'dark reference')
 
     # Special case for threaded reader
-    if isinstance(reader, SectorThreadedReader):
+    if isinstance(reader, (SectorThreadedReader, SectorThreadedMultiPassReader)):
         args = [reader]
 
         if darkreference is not None:

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -105,8 +105,11 @@ def reader(path, version=FileVersion.VERSION1, backend=None, **options):
                 raise Exception('The multi pass threaded reader only support file verison 5')
 
             reader = SectorThreadedMultiPassReader(path, **options)
-        else:
+        elif backend is None:
             reader = SectorReader(path, version)
+        # Unrecognized backend
+        else:
+            raise ValueError(f'Unrecongnized backend: "{backend}"')
     else:
         reader = Reader(path, version)
 

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -506,11 +506,13 @@ std::vector<uint32_t> electronCount(std::vector<float>& frame,
 }
 
 template <typename Reader, typename FrameType, bool dark = true>
-ElectronCountedData electronCount(
-  Reader* reader, const float darkReference[],
-  int thresholdNumberOfBlocks, int numberOfSamples,
-  double backgroundThresholdNSigma, double xRayThresholdNSigma,
-  const float gain[], Dimensions2D scanDimensions, bool verbose)
+ElectronCountedData electronCount(Reader* reader, const float darkReference[],
+                                  int thresholdNumberOfBlocks,
+                                  int numberOfSamples,
+                                  double backgroundThresholdNSigma,
+                                  double xRayThresholdNSigma,
+                                  const float gain[],
+                                  Dimensions2D scanDimensions, bool verbose)
 {
   // This is where we will save the electron events as the calculated
   std::vector<std::vector<uint32_t>> events;
@@ -668,63 +670,7 @@ ElectronCountedData electronCount(
 }
 
 template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, const float darkReference[],
-  int thresholdNumberOfBlocks, int numberOfSamples,
-  double backgroundThresholdNSigma, double xRayThresholdNSigma,
-  const float gain[], Dimensions2D scanDimensions, bool verbose)
-{
-  return electronCount<Reader, float>(reader, darkReference, thresholdNumberOfBlocks,
-                              numberOfSamples, backgroundThresholdNSigma,
-                              xRayThresholdNSigma, gain, scanDimensions,
-                              verbose);
-}
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, Image<float>& darkReference,
-  int thresholdNumberOfBlocks, int numberOfSamples,
-  double backgroundThresholdNSigma, double xRayThresholdNSigma,
-  const float gain[], Dimensions2D scanDimensions, bool verbose)
-{
-  return electronCount<Reader, float>(reader, darkReference.data.get(),
-                              thresholdNumberOfBlocks, numberOfSamples,
-                              backgroundThresholdNSigma, xRayThresholdNSigma,
-                              gain, scanDimensions, verbose);
-}
-
-template <typename Reader>
-ElectronCountedData electronCount(Reader* reader,
-                                  const float darkReference[],
-                                  int thresholdNumberOfBlocks,
-                                  int numberOfSamples,
-                                  double backgroundThresholdNSigma,
-                                  double xRayThresholdNSigma,
-                                  Dimensions2D scanDimensions, bool verbose)
-{
-  return electronCount<Reader, uint16_t>(reader, darkReference, thresholdNumberOfBlocks,
-                                 numberOfSamples, backgroundThresholdNSigma,
-                                 xRayThresholdNSigma, nullptr, scanDimensions,
-                                 verbose);
-}
-
-template <typename Reader>
-ElectronCountedData electronCount(Reader* reader,
-                                  Image<float>& darkReference,
-                                  int thresholdNumberOfBlocks,
-                                  int numberOfSamples,
-                                  double backgroundThresholdNSigma,
-                                  double xRayThresholdNSigma,
-                                  Dimensions2D scanDimensions, bool verbose)
-{
-  return electronCount<Reader, uint16_t>(reader, darkReference.data.get(),
-                                 thresholdNumberOfBlocks, numberOfSamples,
-                                 backgroundThresholdNSigma, xRayThresholdNSigma,
-                                 nullptr, scanDimensions, verbose);
-}
-
-template <typename Reader>
-ElectronCountedData electronCount(Reader* reader,
+ElectronCountedData electronCount(Reader* reader, const float darkReference[],
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
                                   double backgroundThresholdNSigma,
@@ -732,15 +678,71 @@ ElectronCountedData electronCount(Reader* reader,
                                   const float gain[],
                                   Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<Reader, float, false>(reader, nullptr, thresholdNumberOfBlocks,
-                                     numberOfSamples, backgroundThresholdNSigma,
-                                     xRayThresholdNSigma, gain, scanDimensions,
-                                     verbose);
+  return electronCount<Reader, float>(
+    reader, darkReference, thresholdNumberOfBlocks, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma, gain, scanDimensions,
+    verbose);
 }
 
 template <typename Reader>
-ElectronCountedData electronCount(Reader* reader,
+ElectronCountedData electronCount(Reader* reader, Image<float>& darkReference,
                                   int thresholdNumberOfBlocks,
+                                  int numberOfSamples,
+                                  double backgroundThresholdNSigma,
+                                  double xRayThresholdNSigma,
+                                  const float gain[],
+                                  Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount<Reader, float>(
+    reader, darkReference.data.get(), thresholdNumberOfBlocks, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma, gain, scanDimensions,
+    verbose);
+}
+
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader, const float darkReference[],
+                                  int thresholdNumberOfBlocks,
+                                  int numberOfSamples,
+                                  double backgroundThresholdNSigma,
+                                  double xRayThresholdNSigma,
+                                  Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount<Reader, uint16_t>(
+    reader, darkReference, thresholdNumberOfBlocks, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma, nullptr, scanDimensions,
+    verbose);
+}
+
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader, Image<float>& darkReference,
+                                  int thresholdNumberOfBlocks,
+                                  int numberOfSamples,
+                                  double backgroundThresholdNSigma,
+                                  double xRayThresholdNSigma,
+                                  Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount<Reader, uint16_t>(
+    reader, darkReference.data.get(), thresholdNumberOfBlocks, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma, nullptr, scanDimensions,
+    verbose);
+}
+
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader, int thresholdNumberOfBlocks,
+                                  int numberOfSamples,
+                                  double backgroundThresholdNSigma,
+                                  double xRayThresholdNSigma,
+                                  const float gain[],
+                                  Dimensions2D scanDimensions, bool verbose)
+{
+  return electronCount<Reader, float, false>(
+    reader, nullptr, thresholdNumberOfBlocks, numberOfSamples,
+    backgroundThresholdNSigma, xRayThresholdNSigma, gain, scanDimensions,
+    verbose);
+}
+
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader, int thresholdNumberOfBlocks,
                                   int numberOfSamples,
                                   double backgroundThresholdNSigma,
                                   double xRayThresholdNSigma,
@@ -855,100 +857,80 @@ template ElectronCountedData electronCount(PyReader::iterator first,
 // Instantiate for threaded readers
 
 // SectorStreamThreadedReader
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamThreadedReader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamThreadedReader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamThreadedReader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamThreadedReader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamThreadedReader* reader, int thresholdNumberOfBlocks = 1,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10, const float gain[] = nullptr,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
-template
-ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader,
-  int thresholdNumberOfBlocks = 1,
-  int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10,
-  Dimensions2D scanDimensions = { 0, 0 },
+template ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
 // SectorStreamMultiPassThreadedReader
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamMultiPassThreadedReader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamMultiPassThreadedReader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamMultiPassThreadedReader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamMultiPassThreadedReader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
-template
-ElectronCountedData electronCount(
+template ElectronCountedData electronCount(
   SectorStreamMultiPassThreadedReader* reader, int thresholdNumberOfBlocks = 1,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10, const float gain[] = nullptr,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
-template
-ElectronCountedData electronCount(
-  SectorStreamMultiPassThreadedReader* reader,
-  int thresholdNumberOfBlocks = 1,
-  int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10,
-  Dimensions2D scanDimensions = { 0, 0 },
+template ElectronCountedData electronCount(
+  SectorStreamMultiPassThreadedReader* reader, int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
-
-
 }

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -505,9 +505,9 @@ std::vector<uint32_t> electronCount(std::vector<float>& frame,
                               backgroundThreshold, xRayThreshold, gain);
 }
 
-template <typename FrameType, bool dark = true>
+template <typename Reader, typename FrameType, bool dark = true>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const float darkReference[],
+  Reader* reader, const float darkReference[],
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[], Dimensions2D scanDimensions, bool verbose)
@@ -667,31 +667,34 @@ ElectronCountedData electronCount(
   return ret;
 }
 
+template <typename Reader>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const float darkReference[],
+  Reader* reader, const float darkReference[],
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[], Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<float>(reader, darkReference, thresholdNumberOfBlocks,
+  return electronCount<Reader, float>(reader, darkReference, thresholdNumberOfBlocks,
                               numberOfSamples, backgroundThresholdNSigma,
                               xRayThresholdNSigma, gain, scanDimensions,
                               verbose);
 }
 
+template <typename Reader>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, Image<float>& darkReference,
+  Reader* reader, Image<float>& darkReference,
   int thresholdNumberOfBlocks, int numberOfSamples,
   double backgroundThresholdNSigma, double xRayThresholdNSigma,
   const float gain[], Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<float>(reader, darkReference.data.get(),
+  return electronCount<Reader, float>(reader, darkReference.data.get(),
                               thresholdNumberOfBlocks, numberOfSamples,
                               backgroundThresholdNSigma, xRayThresholdNSigma,
                               gain, scanDimensions, verbose);
 }
 
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader,
                                   const float darkReference[],
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
@@ -699,13 +702,14 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
                                   double xRayThresholdNSigma,
                                   Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<uint16_t>(reader, darkReference, thresholdNumberOfBlocks,
+  return electronCount<Reader, uint16_t>(reader, darkReference, thresholdNumberOfBlocks,
                                  numberOfSamples, backgroundThresholdNSigma,
                                  xRayThresholdNSigma, nullptr, scanDimensions,
                                  verbose);
 }
 
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader,
                                   Image<float>& darkReference,
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
@@ -713,13 +717,14 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
                                   double xRayThresholdNSigma,
                                   Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<uint16_t>(reader, darkReference.data.get(),
+  return electronCount<Reader, uint16_t>(reader, darkReference.data.get(),
                                  thresholdNumberOfBlocks, numberOfSamples,
                                  backgroundThresholdNSigma, xRayThresholdNSigma,
                                  nullptr, scanDimensions, verbose);
 }
 
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader,
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
                                   double backgroundThresholdNSigma,
@@ -727,20 +732,21 @@ ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
                                   const float gain[],
                                   Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<float, false>(reader, nullptr, thresholdNumberOfBlocks,
+  return electronCount<Reader, float, false>(reader, nullptr, thresholdNumberOfBlocks,
                                      numberOfSamples, backgroundThresholdNSigma,
                                      xRayThresholdNSigma, gain, scanDimensions,
                                      verbose);
 }
 
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader,
                                   int thresholdNumberOfBlocks,
                                   int numberOfSamples,
                                   double backgroundThresholdNSigma,
                                   double xRayThresholdNSigma,
                                   Dimensions2D scanDimensions, bool verbose)
 {
-  return electronCount<uint16_t, false>(
+  return electronCount<Reader, uint16_t, false>(
     reader, nullptr, thresholdNumberOfBlocks, numberOfSamples,
     backgroundThresholdNSigma, xRayThresholdNSigma, nullptr, scanDimensions,
     verbose);
@@ -845,4 +851,104 @@ template ElectronCountedData electronCount(PyReader::iterator first,
                                            double backgroundThreshold,
                                            double xRayThreshold,
                                            Dimensions2D scanDimensions);
+
+// Instantiate for threaded readers
+
+// SectorStreamThreadedReader
+template
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, Image<float>& darkreference,
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, const float darkreference[],
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, Image<float>& darkreference,
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
+  bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, const float darkreference[],
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
+  bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader, int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10, const float gain[] = nullptr,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamThreadedReader* reader,
+  int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 },
+  bool verbose = false);
+
+// SectorStreamMultiPassThreadedReader
+template
+ElectronCountedData electronCount(
+  SectorStreamMultiPassThreadedReader* reader, Image<float>& darkreference,
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamMultiPassThreadedReader* reader, const float darkreference[],
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamMultiPassThreadedReader* reader, Image<float>& darkreference,
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
+  bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamMultiPassThreadedReader* reader, const float darkreference[],
+  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
+  bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamMultiPassThreadedReader* reader, int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10, const float gain[] = nullptr,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template
+ElectronCountedData electronCount(
+  SectorStreamMultiPassThreadedReader* reader,
+  int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 },
+  bool verbose = false);
+
+
 }

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -55,39 +55,45 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
                                   double xRayThreshold,
                                   Dimensions2D scanDimensions = { 0, 0 });
 
+template <typename Reader>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, Image<float>& darkreference,
+  Reader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
+template <typename Reader>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const float darkreference[],
+  Reader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
+template <typename Reader>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, Image<float>& darkreference,
+  Reader* reader, Image<float>& darkreference,
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
+template <typename Reader>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, const float darkreference[],
+  Reader* reader, const float darkreference[],
   int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
   double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
   const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
   bool verbose = false);
 
+template <typename Reader>
 ElectronCountedData electronCount(
-  SectorStreamThreadedReader* reader, int thresholdNumberOfBlocks = 1,
+  Reader* reader, int thresholdNumberOfBlocks = 1,
   int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
   double xRayThresholdNSigma = 10, const float gain[] = nullptr,
   Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 
-ElectronCountedData electronCount(SectorStreamThreadedReader* reader,
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader,
                                   int thresholdNumberOfBlocks = 1,
                                   int numberOfSamples = 20,
                                   double backgroundThresholdNSigma = 4,

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -56,50 +56,49 @@ ElectronCountedData electronCount(InputIt first, InputIt last,
                                   Dimensions2D scanDimensions = { 0, 0 });
 
 template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, Image<float>& darkreference,
-  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
-  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, const float darkreference[],
-  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
-  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, Image<float>& darkreference,
-  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
-  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
-  bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, const float darkreference[],
-  int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
-  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
-  bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, int thresholdNumberOfBlocks = 1,
-  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10, const float gain[] = nullptr,
-  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(Reader* reader,
+ElectronCountedData electronCount(Reader* reader, Image<float>& darkreference,
                                   int thresholdNumberOfBlocks = 1,
                                   int numberOfSamples = 20,
                                   double backgroundThresholdNSigma = 4,
                                   double xRayThresholdNSigma = 10,
                                   Dimensions2D scanDimensions = { 0, 0 },
                                   bool verbose = false);
+
+template <typename Reader>
+ElectronCountedData electronCount(Reader* reader, const float darkreference[],
+                                  int thresholdNumberOfBlocks = 1,
+                                  int numberOfSamples = 20,
+                                  double backgroundThresholdNSigma = 4,
+                                  double xRayThresholdNSigma = 10,
+                                  Dimensions2D scanDimensions = { 0, 0 },
+                                  bool verbose = false);
+
+template <typename Reader>
+ElectronCountedData electronCount(
+  Reader* reader, Image<float>& darkreference, int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10, const float gain[] = nullptr,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template <typename Reader>
+ElectronCountedData electronCount(
+  Reader* reader, const float darkreference[], int thresholdNumberOfBlocks = 1,
+  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
+  double xRayThresholdNSigma = 10, const float gain[] = nullptr,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+
+template <typename Reader>
+ElectronCountedData electronCount(
+  Reader* reader, int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
+  bool verbose = false);
+
+template <typename Reader>
+ElectronCountedData electronCount(
+  Reader* reader, int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
+  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
+  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
 }
 
 #endif /* STEMPY_ELECTRON_H_ */

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -846,7 +846,12 @@ void  SectorStreamMultiPassThreadedReader::readHeaders() {
             header.frameDimensions.second * header.imagesInBlock;
 
       auto imageNumber = header.imageNumbers[0];
-      auto &frameMap = m_scanMap[imageNumber];
+      auto &frameMaps = m_scanMap[imageNumber];
+
+      // Protect initialization of the map with the correct mutex
+      std::unique_lock<std::mutex> lock(*m_scanPositionMutexes[imageNumber].get());
+      auto &frameMap = frameMaps[header.frameNumber];
+      lock.unlock();
       auto &sectorLocation = frameMap[sector];
 
       sectorLocation.sector = sector;

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -806,16 +806,6 @@ bool SectorStreamThreadedReader::nextStream(StreamQueueEntry& streamQueueEntry)
 }
 
 SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
-  const std::string& path)
-  : SectorStreamThreadedReader(path, 5, -1)
-{}
-
-SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
-  const std::vector<std::string>& files)
-  : SectorStreamThreadedReader(files, 5, -1)
-{}
-
-SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
   const std::string& path, int threads)
   : SectorStreamThreadedReader(path, 5, threads)
 {}

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -804,4 +804,58 @@ bool SectorStreamThreadedReader::nextStream(StreamQueueEntry& streamQueueEntry)
 
   return true;
 }
+
+SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(const std::string& path)
+  : SectorStreamThreadedReader(path, 5, -1)
+{
+
+}
+
+SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
+  const std::vector<std::string>& files)
+  : SectorStreamThreadedReader(files, 5, -1)
+{
+
+}
+
+SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(const std::string& path,
+                                                       int threads)
+  : SectorStreamThreadedReader(path, 5, threads)
+{
+
+}
+
+SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
+  const std::vector<std::string>& files, int threads)
+  : SectorStreamThreadedReader(files, 5, threads)
+{
+
+}
+
+// Read the headers and save the locations of the blocks to form the "frame maps"
+void  SectorStreamMultiPassThreadedReader::readHeaders() {
+  while (m_processed < m_streams.size()) {
+    auto &sectorStream = m_streams[m_processed++];
+    auto &stream = sectorStream.stream;
+    auto sector = sectorStream.sector;
+
+    while(stream->peek() != EOF) {
+      // First read the header
+      auto header = readHeader(*stream);
+      auto dataSize = header.frameDimensions.first *
+            header.frameDimensions.second * header.imagesInBlock;
+
+      auto imageNumber = header.imageNumbers[0];
+      auto &frameMap = m_scanMap[imageNumber];
+      auto &sectorLocation = frameMap[sector];
+
+      sectorLocation.sector = sector;
+      sectorLocation.sectorStream = &sectorStream;
+      sectorLocation.offset = stream->tellg();
+      stream->seekg(dataSize * sizeof(uint16_t), stream->cur);
+    }
+  }
+}
+
+
 }

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -805,54 +805,50 @@ bool SectorStreamThreadedReader::nextStream(StreamQueueEntry& streamQueueEntry)
   return true;
 }
 
-SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(const std::string& path)
+SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
+  const std::string& path)
   : SectorStreamThreadedReader(path, 5, -1)
-{
-
-}
+{}
 
 SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
   const std::vector<std::string>& files)
   : SectorStreamThreadedReader(files, 5, -1)
-{
+{}
 
-}
-
-SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(const std::string& path,
-                                                       int threads)
+SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
+  const std::string& path, int threads)
   : SectorStreamThreadedReader(path, 5, threads)
-{
-
-}
+{}
 
 SectorStreamMultiPassThreadedReader::SectorStreamMultiPassThreadedReader(
   const std::vector<std::string>& files, int threads)
   : SectorStreamThreadedReader(files, 5, threads)
+{}
+
+// Read the headers and save the locations of the blocks to form the "frame
+// maps"
+void SectorStreamMultiPassThreadedReader::readHeaders()
 {
-
-}
-
-// Read the headers and save the locations of the blocks to form the "frame maps"
-void  SectorStreamMultiPassThreadedReader::readHeaders() {
   while (m_processed < m_streams.size()) {
-    auto &sectorStream = m_streams[m_processed++];
-    auto &stream = sectorStream.stream;
+    auto& sectorStream = m_streams[m_processed++];
+    auto& stream = sectorStream.stream;
     auto sector = sectorStream.sector;
 
-    while(stream->peek() != EOF) {
+    while (stream->peek() != EOF) {
       // First read the header
       auto header = readHeader(*stream);
       auto dataSize = header.frameDimensions.first *
-            header.frameDimensions.second * header.imagesInBlock;
+                      header.frameDimensions.second * header.imagesInBlock;
 
       auto imageNumber = header.imageNumbers[0];
-      auto &frameMaps = m_scanMap[imageNumber];
+      auto& frameMaps = m_scanMap[imageNumber];
 
       // Protect initialization of the map with the correct mutex
-      std::unique_lock<std::mutex> lock(*m_scanPositionMutexes[imageNumber].get());
-      auto &frameMap = frameMaps[header.frameNumber];
+      std::unique_lock<std::mutex> lock(
+        *m_scanPositionMutexes[imageNumber].get());
+      auto& frameMap = frameMaps[header.frameNumber];
       lock.unlock();
-      auto &sectorLocation = frameMap[sector];
+      auto& sectorLocation = frameMap[sector];
 
       sectorLocation.sector = sector;
       sectorLocation.sectorStream = &sectorStream;
@@ -861,6 +857,4 @@ void  SectorStreamMultiPassThreadedReader::readHeaders() {
     }
   }
 }
-
-
 }

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -561,8 +561,10 @@ std::future<void> SectorStreamMultiPassThreadedReader::readAll(Functor& func)
 
   // Resize the vector to hold the frame sector locations for the scan
   auto scanSize = header.scanDimensions.first * header.scanDimensions.second;
+  m_scanMap.clear();
   m_scanMap.resize(scanSize);
   // Allocate the mutexes
+  m_scanPositionMutexes.clear();
   for (auto i = 0; i < scanSize; i++) {
     m_scanPositionMutexes.push_back(std::make_unique<std::mutex>());
   }

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -475,11 +475,10 @@ using ScanMap = std::vector<std::map<uint32_t, std::array<SectorLocation, 4>>>;
 class SectorStreamMultiPassThreadedReader : public SectorStreamThreadedReader
 {
 public:
-  SectorStreamMultiPassThreadedReader(const std::string& path);
-  SectorStreamMultiPassThreadedReader(const std::vector<std::string>& files);
-  SectorStreamMultiPassThreadedReader(const std::string& path, int threads = 0);
+  SectorStreamMultiPassThreadedReader(const std::string& path,
+                                      int threads = -1);
   SectorStreamMultiPassThreadedReader(const std::vector<std::string>& files,
-                                      int threads = 0);
+                                      int threads = -1);
 
   template <typename Functor>
   std::future<void> readAll(Functor& f);


### PR DESCRIPTION
This readers the headers first to build up a frame map and then uses a second pass to read the data. This reduces memory usage and will provide the opportunity to parallelize across nodes.