### PR TITLE
Skip pip install stempy for read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,4 @@ sphinx:
 python:
   version: 3.7
   install:
-    - method: pip
-      path: .
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ sphinx==2.3.1
 pygments==2.4.2
 sphinx-rtd-theme==0.4.3
 recommonmark==0.6.0
+
+deprecation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ import sys
 import sphinx_rtd_theme
 from unittest import mock
 
-sys.path.insert(0, os.path.abspath('../../python/stempy'))
+sys.path.insert(0, os.path.abspath('../../python'))
 
 
 # -- Project information -----------------------------------------------------
@@ -63,6 +63,7 @@ _io_mock._sector_reader = MockReader
 _io_mock._threaded_reader = object
 _io_mock._reader = object
 _io_mock._pyreader = object
+_io_mock._threaded_multi_pass_reader = object
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -97,7 +98,8 @@ def autodoc_skip_member_handler(app, what, name, obj, skip, options):
         'ReaderMixin',
         'PyReader',
         'SectorReader',
-        'get_hdf5_reader'
+        'get_hdf5_reader',
+        'SectorThreadedMultiPassReader',
     ]
 
     return name in exclude_names


### PR DESCRIPTION
It isn't really needed - we are already appending the path
to the python files to the sys.path. And we are mocking the
stempy._io and stempy._image imports already.

This also adds _threaded_multi_pass_reader to the list of _io_mock
objects to prevent an error involving multiple inheritance with
different metaclasses.

deprecation is also added as a requirement for the docs, since it
is needed to display the deprecation in the documentation.