### PR TITLE
Dereference symlinks to fix singularity

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN mkdir -p /build/stempy && \
 
 # Install stempy
 RUN pip3 install -r /source/stempy/requirements.txt && \
-  cp -r /build/stempy/lib/stempy /usr/local/lib/python3.7/site-packages && \
+  cp -r -L /build/stempy/lib/stempy /usr/local/lib/python3.7/site-packages && \
   pip3 install matplotlib click imageio ncempy
 
 RUN rm -rf /build

--- a/docker/Dockerfile.scipy-notebook
+++ b/docker/Dockerfile.scipy-notebook
@@ -50,7 +50,7 @@ RUN mkdir -p build/stempy && \
 
 # Install stempy
 RUN pip install -r source/stempy/requirements.txt && \
-    cp -r build/stempy/lib/stempy /opt/conda/lib/python3.8/site-packages
+    cp -r -L build/stempy/lib/stempy /opt/conda/lib/python3.8/site-packages
 
 RUN rm -rf build
 


### PR DESCRIPTION
Previously, symlinks were being preserved when the copy occurred. The
symlinks pointed into the /home/jovyan directory.

When a singularity shell was started, the user would be "jovyan", so
there would be no issue importing the files.

However, if jupyter was started instead, the user would be the current
user on the host OS. And this user would have permissions issues with
reading into the /home/jovyan directory.

To fix this, dereference the symlinks on `cp` to avoid having symlinks
pointing into `/home/jovyan`.

This was tested and seems to have fixed the issue.