### PR TITLE
Skip musl wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,9 +9,9 @@ on:
   pull_request:
 
 env:
-  # Only support 64-bit CPython >= 3.6
+  # Only support 64-bit CPython >= 3.7
   # Skip CPython 3.10 while it's young. We'll add it back later.
-  CIBW_SKIP: "cp27-* cp35-* pp* *-manylinux_i686 *-win32 cp310-*"
+  CIBW_SKIP: "cp27-* cp35-* cp36-* pp* *-manylinux_i686 *-win32 cp310-*"
 
   # This has some of the software we need pre-installed on it
   CIBW_MANYLINUX_X86_64_IMAGE: openchemistry/stempy_wheel_builder

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,9 +9,9 @@ on:
   pull_request:
 
 env:
-  # Only support 64-bit CPython >= 3.7
+  # Only support 64-bit CPython >= 3.6
   # Skip CPython 3.10 while it's young. We'll add it back later.
-  CIBW_SKIP: "cp27-* cp35-* cp36-* pp* *-manylinux_i686 *-win32 cp310-*"
+  CIBW_SKIP: "cp27-* cp35-* pp* *-manylinux_i686 *-musllinux_* *-win32 cp310-*"
 
   # This has some of the software we need pre-installed on it
   CIBW_MANYLINUX_X86_64_IMAGE: openchemistry/stempy_wheel_builder


### PR DESCRIPTION
~It's end of life is coming in \~7 weeks, and the latest cibuildwheel
no longer supports it.~

~We can go ahead and remove it, since we do not believe anyone has a
specific need for the python 3.6 wheels.~

Looks like it was actually musl wheels that were the problem. CI build wheel started supporting musl wheels since a couple of weeks ago. We don't need any immediate support for them, so I added them to the skip list, and I put python 3.6 back on.