### PR TITLE
Add extra for loop to account for multiple frames

### DIFF
--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -568,8 +568,9 @@ def calculate_sum_sparse(electron_counts, frame_dimensions):
     :rtype: numpy.ndarray
     """
     dp = np.zeros((frame_dimensions[0] * frame_dimensions[1]), '<u8')
-    for ii, ev in enumerate(electron_counts):
-        dp[ev] += 1
+    for ev in electron_counts:
+        for ee in ev:
+            dp[ee] += 1
     dp = dp.reshape(frame_dimensions)
     return dp
 


### PR DESCRIPTION
This fixes the issue with `stempy.image.calculate_sum_sparse()` which incorrectly calculated results for scans with multiple frames per probe position