### PR TITLE
Add metadata to SparseArray

### DIFF
--- a/examples/electron_count.py
+++ b/examples/electron_count.py
@@ -43,7 +43,7 @@ if args.threaded:
 else:
     print('unthreaded')
     threaded = None
- 
+
 scanName = 'data_scan{:010}_'.format(scanNum)
 #scanName = 'data_scan{}_'.format(scanNum)
 
@@ -56,7 +56,7 @@ for ii in range(1,5):
         # Temporarily staged files
         drive_name += '/temp'
     drives.append(Path(drive_name))
-    
+
 print('Looking for files in:')
 for d in drives:
     print(d)
@@ -102,15 +102,18 @@ if outPath.exists():
         outPath2 = outPath.with_name(outPath.stem + '_{:03d}.h5'.format(ii))
 else:
     outPath2 = outPath
-print('Saving to {}'.format(outPath2))
-stio.save_electron_counts(str(outPath2), ee)
 
 # Add meta data
-with h5py.File(outPath2,'a') as f0:
-    user_group = f0.create_group('user')
-    user_group.attrs['threshold sigma'] = threshold
-    user_group.attrs['scan number'] = scanNum
-    user_group.attrs['threaded'] = args.threaded
-    user_group.attrs['date processed'] = datetime.now().strftime('%Y/%m/%d %H:%M:%S')
-    user_group.attrs['process time (s)'] = full_time 
+ee.metadata.update({
+    'user': {
+        'threshold sigma': threshold,
+        'scan number': scanNum,
+        'threaded': args.threaded,
+        'date processed': datetime.now().strftime('%Y/%m/%d %H:%M:%S'),
+        'process time (s)': full_time,
+    }
+})
+
+print('Saving to {}'.format(outPath2))
+stio.save_electron_counts(str(outPath2), ee)
 print('done')

--- a/python/image.cpp
+++ b/python/image.cpp
@@ -38,11 +38,13 @@ struct ElectronCountedDataPyArray
       data.push_back(vectorToPyArray(std::move(vec)));
     }
 
+    metadata = other.metadata;
     scanDimensions = other.scanDimensions;
     frameDimensions = other.frameDimensions;
   }
 
   std::vector<py::array_t<uint32_t>> data;
+  ElectronCountedMetadata metadata;
 
   Dimensions2D scanDimensions = { 0, 0 };
   Dimensions2D frameDimensions = { 0, 0 };
@@ -390,15 +392,40 @@ PYBIND11_MODULE(_image, m)
                                   py::buffer_protocol())
     .def_readonly("data", &ElectronCountedData::data)
     .def_readonly("scan_dimensions", &ElectronCountedData::scanDimensions)
-    .def_readonly("frame_dimensions", &ElectronCountedData::frameDimensions);
+    .def_readonly("frame_dimensions", &ElectronCountedData::frameDimensions)
+    .def_readonly("metadata", &ElectronCountedData::metadata);
 
   py::class_<ElectronCountedDataPyArray>(m, "_electron_counted_data_pyarray",
                                          py::buffer_protocol())
     .def_readonly("data", &ElectronCountedDataPyArray::data)
+    .def_readonly("metadata", &ElectronCountedDataPyArray::metadata)
     .def_readonly("scan_dimensions",
                   &ElectronCountedDataPyArray::scanDimensions)
     .def_readonly("frame_dimensions",
                   &ElectronCountedDataPyArray::frameDimensions);
+
+  py::class_<ElectronCountedMetadata>(m, "_electron_counted_metadata",
+                                      py::buffer_protocol())
+    .def_readonly("threshold_calculated",
+                  &ElectronCountedMetadata::thresholdCalculated)
+    .def_readonly("background_threshold",
+                  &ElectronCountedMetadata::backgroundThreshold)
+    .def_readonly("x_ray_threshold", &ElectronCountedMetadata::xRayThreshold)
+    .def_readonly("number_of_samples",
+                  &ElectronCountedMetadata::numberOfSamples)
+    .def_readonly("min_sample", &ElectronCountedMetadata::minSample)
+    .def_readonly("max_sample", &ElectronCountedMetadata::maxSample)
+    .def_readonly("mean", &ElectronCountedMetadata::mean)
+    .def_readonly("variance", &ElectronCountedMetadata::variance)
+    .def_readonly("std_dev", &ElectronCountedMetadata::stdDev)
+    .def_readonly("number_of_bins", &ElectronCountedMetadata::numberOfBins)
+    .def_readonly("x_ray_threshold_n_sigma",
+                  &ElectronCountedMetadata::xRayThresholdNSigma)
+    .def_readonly("background_threshold_n_sigma",
+                  &ElectronCountedMetadata::backgroundThresholdNSigma)
+    .def_readonly("optimized_mean", &ElectronCountedMetadata::optimizedMean)
+    .def_readonly("optimized_std_dev",
+                  &ElectronCountedMetadata::optimizedStdDev);
 
   // Add more template instantiations as we add more types of iterators
   m.def("create_stem_images",

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -410,11 +410,13 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
 
     # Convert to numpy array
     np_data = np.array([np.array(x, copy=False) for x in data.data], dtype=np.object)
+    metadata = _electron_counted_metadata_to_dict(data.metadata)
 
     kwargs = {
         'data': np_data,
         'scan_shape': data.scan_dimensions[::-1],
         'frame_shape': data.frame_dimensions,
+        'metadata': {'electron_counting': metadata},
     }
     array = SparseArray(**kwargs)
 
@@ -674,3 +676,29 @@ def phase_from_com(com, theta=0, flip=False, reg=1e-10):
 
     # Return real part of the inverse Fourier transform
     return np.real(np.fft.ifft2(numerator / denominator))
+
+
+def _electron_counted_metadata_to_dict(metadata):
+    # Convert the electron counted metadata to a python dict
+    attributes = [
+        'threshold_calculated',
+        'background_threshold',
+        'x_ray_threshold',
+        'number_of_samples',
+        'min_sample',
+        'max_sample',
+        'mean',
+        'variance',
+        'std_dev',
+        'number_of_bins',
+        'x_ray_threshold_n_sigma',
+        'background_threshold_n_sigma',
+        'optimized_mean',
+        'optimized_std_dev',
+    ]
+
+    ret = {}
+    for name in attributes:
+        ret[name] = getattr(metadata, name)
+
+    return ret

--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -749,21 +749,16 @@ def save_dict_to_h5(d, group):
             new_group = group.require_group(k)
             save_dict_to_h5(v, new_group)
         else:
-            group[k] = v
+            group.attrs[k] = v
 
 
 def load_h5_to_dict(group, d):
     import h5py
 
+    for k, v in group.attrs.items():
+        d[k] = v
+
     for k, v in group.items():
         if isinstance(v, h5py.Group):
             d[k] = {}
             load_h5_to_dict(v, d[k])
-        else:
-            # h5py no longer automatically converts to string for us
-            # convert it manually...
-            string_dtype = h5py.check_string_dtype(v.dtype)
-            if string_dtype is not None and string_dtype.encoding == 'utf-8':
-                v = v.asstr()
-
-            d[k] = v[()]

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -702,6 +702,23 @@ ElectronCountedData electronCount(Reader* reader, const float darkReference[],
 #endif
 
   ElectronCountedData ret;
+  auto& metadata = ret.metadata;
+
+  metadata.thresholdCalculated = calculateThreshold;
+  metadata.backgroundThreshold = threshold.backgroundThreshold;
+  metadata.xRayThreshold = threshold.xRayThreshold;
+  metadata.numberOfSamples = threshold.numberOfSamples;
+  metadata.minSample = threshold.minSample;
+  metadata.maxSample = threshold.maxSample;
+  metadata.mean = threshold.mean;
+  metadata.variance = threshold.variance;
+  metadata.stdDev = threshold.stdDev;
+  metadata.numberOfBins = threshold.numberOfBins;
+  metadata.xRayThresholdNSigma = threshold.xRayThresholdNSigma;
+  metadata.backgroundThresholdNSigma = threshold.backgroundThresholdNSigma;
+  metadata.optimizedMean = threshold.optimizedMean;
+  metadata.optimizedStdDev = threshold.optimizedStdDev;
+
   ret.data = events;
   ret.scanDimensions = scanDimensions;
   ret.frameDimensions = frameSize;

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -7,10 +7,29 @@ namespace stempy {
 
 class SectorStreamThreadedReader;
 
+struct ElectronCountedMetadata
+{
+  bool thresholdCalculated = true;
+  double backgroundThreshold = 0.0;
+  double xRayThreshold = 0.0;
+  int numberOfSamples = 0;
+  double minSample = 0;
+  double maxSample = 0;
+  double mean = 0.0;
+  double variance = 0.0;
+  double stdDev = 0.0;
+  int numberOfBins = 0;
+  double xRayThresholdNSigma = 0.0;
+  double backgroundThresholdNSigma = 0.0;
+  double optimizedMean = 0.0;
+  double optimizedStdDev = 0.0;
+};
+
 struct ElectronCountedData
 {
   std::vector<std::vector<uint32_t>> data;
 
+  ElectronCountedMetadata metadata;
   Dimensions2D scanDimensions = { 0, 0 };
   Dimensions2D frameDimensions = { 0, 0 };
 };

--- a/tests/test_sparse_array.py
+++ b/tests/test_sparse_array.py
@@ -332,6 +332,16 @@ def test_round_trip_hdf5(sparse_array_small):
     # Test writing to HDF5 then reading back in
     original = sparse_array_small
 
+    # Store some metadata that we will test for
+    original.metadata.update({
+        'nested': {
+            'string': 's',
+        },
+        'array1d': np.arange(3, dtype=int),
+        'array2d': np.arange(9, dtype=np.float32).reshape((3, 3)),
+        'float': np.float64(7.21),
+    })
+
     temp = tempfile.NamedTemporaryFile(delete=False)
     try:
         temp.close()
@@ -343,9 +353,39 @@ def test_round_trip_hdf5(sparse_array_small):
     # These should be equal in every respect
     assert original.scan_shape == array.scan_shape
     assert original.frame_shape == array.frame_shape
+    assert dicts_equal(original.metadata, array.metadata)
 
     for a, b in zip(original.data, array.data):
         assert np.array_equal(a, b)
+
+    original.metadata['float'] = np.float64(6.5)
+    # Now, the metadata shouldn't be equal
+    assert not dicts_equal(original.metadata, array.metadata)
+
+
+def dicts_equal(d1, d2):
+    if d1.keys() != d2.keys():
+        return False
+
+    for k, v1 in d1.items():
+        v2 = d2[k]
+
+        if type(v1) != type(v2):
+            return False
+
+        if isinstance(v1, np.ndarray):
+            if v1.shape != v2.shape:
+                return False
+            if not np.allclose(v1, v2):
+                return False
+        elif isinstance(v1, dict):
+            if not dicts_equal(v1, v2):
+                return False
+        else:
+            if v1 != v2:
+                return False
+
+    return True
 
 
 # Test binning until this number


### PR DESCRIPTION
This adds metadata to the SparseArray class than will be saved/loaded
via HDF5. A basic test was also added to ensure this works.

Now, when electron counting is performed, the metadata on the sparse
array gets set to the electron counting metadata (thresholds mostly).
This way, we can also keep and save the electron counting metadata to
the HDF5 file.

Fixes: #220