### PR TITLE
Separate sparse arrays with same scan position

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -38,11 +38,13 @@ struct ElectronCountedDataPyArray
       data.push_back(vectorToPyArray(std::move(vec)));
     }
 
+    scanPositions = other.scanPositions;
     scanDimensions = other.scanDimensions;
     frameDimensions = other.frameDimensions;
   }
 
   std::vector<py::array_t<uint32_t>> data;
+  std::vector<uint32_t> scanPositions;
 
   Dimensions2D scanDimensions = { 0, 0 };
   Dimensions2D frameDimensions = { 0, 0 };
@@ -389,12 +391,14 @@ PYBIND11_MODULE(_image, m)
   py::class_<ElectronCountedData>(m, "_electron_counted_data",
                                   py::buffer_protocol())
     .def_readonly("data", &ElectronCountedData::data)
+    .def_readonly("scan_positions", &ElectronCountedData::scanPositions)
     .def_readonly("scan_dimensions", &ElectronCountedData::scanDimensions)
     .def_readonly("frame_dimensions", &ElectronCountedData::frameDimensions);
 
   py::class_<ElectronCountedDataPyArray>(m, "_electron_counted_data_pyarray",
                                          py::buffer_protocol())
     .def_readonly("data", &ElectronCountedDataPyArray::data)
+    .def_readonly("scan_positions", &ElectronCountedDataPyArray::scanPositions)
     .def_readonly("scan_dimensions",
                   &ElectronCountedDataPyArray::scanDimensions)
     .def_readonly("frame_dimensions",

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -415,6 +415,7 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         'data': np_data,
         'scan_shape': data.scan_dimensions[::-1],
         'frame_shape': data.frame_dimensions,
+        'scan_positions': data.scan_positions,
     }
     array = SparseArray(**kwargs)
 

--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -79,7 +79,8 @@ class SparseArray:
     array depending on the user-defined settings.
     """
     def __init__(self, data, scan_shape, frame_shape, dtype=np.uint32,
-                 sparse_slicing=True, allow_full_expand=False):
+                 sparse_slicing=True, allow_full_expand=False,
+                 scan_positions=None):
         """Initialize a sparse array.
 
         :param data: the sparse array data, where the arrays represent
@@ -105,6 +106,9 @@ class SparseArray:
                                   attempted anywhere, an exception will
                                   be raised.
         :type allow_full_expand: bool
+        :param scan_positions: the scan position of each sparse data frame.
+                               If None, it will be set to np.arange(num_scans).
+        :type scan_positions: np.ndarray (1D) of int
         """
         self.data = data.ravel()
         self.scan_shape = tuple(scan_shape)
@@ -112,6 +116,30 @@ class SparseArray:
         self.dtype = dtype
         self.sparse_slicing = sparse_slicing
         self.allow_full_expand = allow_full_expand
+
+        if scan_positions is None:
+            scan_positions = np.arange(self._scan_shape_flat[0])
+
+        self.scan_positions = np.asarray(scan_positions)
+
+        # Prevent obscure errors later by validating now
+        self._validate()
+
+    def _validate(self):
+        if len(self.scan_positions) != len(self.data):
+            msg = (
+                f'Length of the scan positions ({len(self.scan_positions)}) '
+                f'must be equal to the length of the data ({len(self.data)})'
+            )
+            raise Exception(msg)
+
+        for i, row in enumerate(self.data):
+            if not np.issubdtype(row.dtype, np.integer):
+                msg = (
+                    f'All rows of data must have integral dtype, but row {i} '
+                    f'has a dtype of {row.dtype}'
+                )
+                raise Exception(msg)
 
     @classmethod
     def from_hdf5(cls, filepath, **init_kwargs):
@@ -129,16 +157,19 @@ class SparseArray:
 
         with h5py.File(filepath, 'r') as f:
             frames = f['electron_events/frames']
-            scan_positions = f['electron_events/scan_positions']
+            scan_positions_group = f['electron_events/scan_positions']
 
             data = frames[()]
-            scan_shape = [scan_positions.attrs[x] for x in ['Nx', 'Ny']]
+            scan_shape = [scan_positions_group.attrs[x] for x in ['Nx', 'Ny']]
             frame_shape = [frames.attrs[x] for x in ['Nx', 'Ny']]
+
+            scan_positions = scan_positions_group[()]
 
         kwargs = {
             'data': data,
             'scan_shape': scan_shape[::-1],
             'frame_shape': frame_shape,
+            'scan_positions': scan_positions,
         }
         kwargs.update(init_kwargs)
         return cls(**kwargs)
@@ -155,9 +186,7 @@ class SparseArray:
         with h5py.File(path, 'a') as f:
             group = f.require_group('electron_events')
             scan_positions = group.create_dataset('scan_positions',
-                                                  (data.shape[0],),
-                                                  dtype=np.int32)
-            scan_positions[...] = [i for i in range(0, data.shape[0])]
+                                                  data=self.scan_positions)
             scan_positions.attrs['Nx'] = self.scan_shape[1]
             scan_positions.attrs['Ny'] = self.scan_shape[0]
 
@@ -276,8 +305,10 @@ class SparseArray:
 
         if self._is_scan_axes(axis):
             ret = np.zeros(self._frame_shape_flat, dtype=dtype)
-            for sparse_frame in self.data:
-                unique, counts = np.unique(sparse_frame, return_counts=True)
+            for position in range(self._scan_shape_flat[0]):
+                data_indices = self._data_indices(position)
+                concatenated = np.concatenate(self.data[data_indices])
+                unique, counts = np.unique(concatenated, return_counts=True)
                 ret[unique] = np.maximum(ret[unique], counts)
             return ret.reshape(self.frame_shape)
 
@@ -311,9 +342,11 @@ class SparseArray:
         if self._is_scan_axes(axis):
             ret = np.full(self._frame_shape_flat, np.iinfo(dtype).max, dtype)
             expanded = np.empty(self._frame_shape_flat, dtype)
-            for sparse_frame in self.data:
+            for position in range(self._scan_shape_flat[0]):
                 expanded[:] = 0
-                unique, counts = np.unique(sparse_frame, return_counts=True)
+                data_indices = self._data_indices(position)
+                concatenated = np.concatenate(self.data[data_indices])
+                unique, counts = np.unique(concatenated, return_counts=True)
                 expanded[unique] = counts
                 ret[:] = np.minimum(ret, expanded)
             return ret.reshape(self.frame_shape)
@@ -348,8 +381,7 @@ class SparseArray:
         if self._is_scan_axes(axis):
             ret = np.zeros(self._frame_shape_flat, dtype=dtype)
             for sparse_frame in self.data:
-                unique, counts = np.unique(sparse_frame, return_counts=True)
-                ret[unique] += counts.astype(dtype)
+                ret[sparse_frame] += 1
             return ret.reshape(self.frame_shape)
 
     @_arithmethic_decorators
@@ -404,31 +436,36 @@ class SparseArray:
             raise ValueError(f'scan_shape must be equally divisible by '
                              f'bin_factor {bin_factor}')
 
+        # No need to modify the data, just the scan shape and the scan
+        # positions.
         new_scan_shape = tuple(x // bin_factor for x in self.scan_shape)
-        flat_new_scan_shape = np.prod(new_scan_shape),
-        new_data = np.empty(flat_new_scan_shape, dtype=object)
-
-        original_reshaped = self.data.reshape(new_scan_shape[0], bin_factor,
-                                              new_scan_shape[1], bin_factor)
+        all_positions = np.arange(self._scan_shape_flat[0])
+        all_positions_reshaped = all_positions.reshape(
+            new_scan_shape[0], bin_factor, new_scan_shape[1], bin_factor)
+        new_scan_positions = np.empty_like(self.scan_positions)
 
         for i in range(new_scan_shape[0]):
             for j in range(new_scan_shape[1]):
                 idx = i * new_scan_shape[1] + j
-                to_combine = original_reshaped[i, :, j, :].ravel()
-                new_data[idx] = np.concatenate(to_combine)
+                scan_position = all_positions[idx]
+                to_change = all_positions_reshaped[i, :, j, :].ravel()
+                to_set = np.concatenate([np.where(self.scan_positions == x)[0]
+                                         for x in to_change])
+                new_scan_positions[to_set] = scan_position
 
         if in_place:
-            self.data = new_data
             self.scan_shape = new_scan_shape
+            self.scan_positions = new_scan_positions
             return self
 
         kwargs = {
-            'data': new_data,
+            'data': self.data.copy(),
             'scan_shape': new_scan_shape,
             'frame_shape': self.frame_shape,
             'dtype': self.dtype,
             'sparse_slicing': self.sparse_slicing,
             'allow_full_expand': self.allow_full_expand,
+            'scan_positions': new_scan_positions,
         }
         return SparseArray(**kwargs)
 
@@ -457,19 +494,47 @@ class SparseArray:
         rows *= (self.frame_shape[0] // bin_factor)
         rows += cols
 
+        new_data = rows
+        new_scan_positions = self.scan_positions
+
+        # Place duplicates in separate frames
+        extra_rows = []
+        extra_scan_positions = []
+        for i, row in enumerate(rows):
+            unique, counts = np.unique(row, return_counts=True)
+            rows[i] = unique
+
+            # Ensure counts can be negative
+            counts = counts.astype(np.int64) - 1
+            while np.any(counts > 0):
+                extra_rows.append(unique[counts > 0])
+                extra_scan_positions.append(self.scan_positions[i])
+                counts -= 1
+
+        if extra_rows:
+            # Resize the new data and add on the extra rows
+            new_size = rows.shape[0] + len(extra_rows)
+            new_data = np.empty(new_size, dtype=object)
+            new_data[:rows.shape[0]] = rows
+            new_data[rows.shape[0]:] = extra_rows
+            new_scan_positions = np.append(self.scan_positions,
+                                           extra_scan_positions)
+
         new_frame_shape = tuple(x // bin_factor for x in self.frame_shape)
         if in_place:
-            self.data = rows
+            self.data = new_data
+            self.scan_positions = new_scan_positions
             self.frame_shape = new_frame_shape
             return self
 
         kwargs = {
-            'data': rows,
+            'data': new_data,
             'scan_shape': self.scan_shape,
             'frame_shape': new_frame_shape,
             'dtype': self.dtype,
             'sparse_slicing': self.sparse_slicing,
             'allow_full_expand': self.allow_full_expand,
+            'scan_positions': new_scan_positions,
         }
         return SparseArray(**kwargs)
 
@@ -523,6 +588,10 @@ class SparseArray:
         return (np.prod(self.frame_shape),)
 
     @property
+    def _scan_shape_flat(self):
+        return (np.prod(self.scan_shape),)
+
+    @property
     def _default_axis(self):
         return tuple(np.arange(len(self.shape)))
 
@@ -533,7 +602,10 @@ class SparseArray:
 
         return len(shape) == 4 and tuple(sorted(axis)) == (0, 1)
 
-    def _sparse_frame(self, indices):
+    def _data_indices(self, scan_position):
+        return np.where(self.scan_positions == scan_position)[0]
+
+    def _sparse_frames(self, indices):
         if not isinstance(indices, (list, tuple)):
             indices = (indices,)
 
@@ -547,7 +619,7 @@ class SparseArray:
         else:
             scan_ind = indices[0] * self.scan_shape[1] + indices[1]
 
-        return self.data[scan_ind]
+        return self.data[self._data_indices(scan_ind)]
 
     def _slice_dense(self, slices, non_slice_indices=None):
         # non_slice_indices indicate which indices should be squeezed
@@ -627,13 +699,28 @@ class SparseArray:
             for i, (s, length) in enumerate(zip(scan_slices, self.scan_shape)):
                 if i not in non_slice_indices:
                     new_scan_shape += (len(slice_range(s, length)),)
-            shaped_data = self.data.reshape(self.scan_shape)
-            new_frames = shaped_data[scan_slices].ravel()
+
+            all_positions = np.arange(self._scan_shape_flat[0]).reshape(
+                self.scan_shape)
+            positions_to_keep = all_positions[scan_slices].ravel()
+
+            # Find all frames that have positions to keep
+            to_keep = np.concatenate([np.where(self.scan_positions == x)[0]
+                                      for x in positions_to_keep])
+            new_frames = self.data[to_keep]
+
+            # Re-number the positions so they go from zero to
+            # len(positions_to_keep).
+            # Sort them so we don't undo the new ordering which is already
+            # a part of the new_frames.
+            new_scan_positions = self.scan_positions[np.sort(to_keep)]
+            for i in range(len(positions_to_keep)):
+                while i not in new_scan_positions:
+                    new_scan_positions[new_scan_positions > i] -= 1
         else:
             new_scan_shape = self.scan_shape
             new_frames = self.data
-
-        new_flat_scan_shape = (np.prod(new_scan_shape),)
+            new_scan_positions = self.scan_positions
 
         if frame_shape_modified:
             new_frame_shape = ()
@@ -641,6 +728,11 @@ class SparseArray:
                                                 self.frame_shape)):
                 if i + len(self.scan_shape) not in non_slice_indices:
                     new_frame_shape += (len(slice_range(s, length)),)
+
+            if not new_frame_shape:
+                # We don't support an empty frame shape.
+                # Just return the dense array instead.
+                return self._slice_dense(slices, non_slice_indices)
 
             # Map old frame indices to new ones. Invalid values will be -1.
             frame_indices = np.arange(self._frame_shape_flat[0]).reshape(
@@ -652,7 +744,7 @@ class SparseArray:
             new_frame_indices_map[valid_flat_frame_indices] = new_indices
 
             # Allocate the new data
-            new_data = np.empty(new_flat_scan_shape, dtype=object)
+            new_data = np.empty(new_frames.shape, dtype=object)
 
             # Now set it
             for i, frame in enumerate(new_frames):
@@ -669,6 +761,7 @@ class SparseArray:
             'dtype': self.dtype,
             'sparse_slicing': self.sparse_slicing,
             'allow_full_expand': self.allow_full_expand,
+            'scan_positions': new_scan_positions,
         }
         return SparseArray(**kwargs)
 
@@ -678,7 +771,7 @@ class SparseArray:
 
         if len(indices) >= len(self.scan_shape):
             scan_indices = indices[:len(self.scan_shape)]
-            sparse_frame = self._sparse_frame(scan_indices)
+            sparse_frames = self._sparse_frames(scan_indices)
 
         if len(indices) < len(self.scan_shape):
             # len(indices) should be 1 and len(scan_shape) should be 2
@@ -690,8 +783,8 @@ class SparseArray:
         elif len(indices) == len(self.scan_shape):
             # Expand the frame this represents
             dp = np.zeros(self._frame_shape_flat, dtype=self.dtype)
-            unique, counts = np.unique(sparse_frame, return_counts=True)
-            dp[unique] += counts.astype(self.dtype)
+            for frame in sparse_frames:
+                dp[frame] += 1
             return dp.reshape(self.frame_shape)
         elif len(indices) == len(self.scan_shape) + 1:
             # The last index is a frame index
@@ -699,19 +792,17 @@ class SparseArray:
             dp = np.zeros((self.frame_shape[1],), dtype=self.dtype)
             start = frame_index * self.frame_shape[1]
             end = start + self.frame_shape[1] - 1
-            in_range = np.logical_and(sparse_frame >= start,
-                                      sparse_frame <= end)
-            clipped_adjusted_sparse_frame = sparse_frame[in_range] - start
-            unique, counts = np.unique(clipped_adjusted_sparse_frame,
-                                       return_counts=True)
-            dp[unique] += counts.astype(self.dtype)
+            for frame in sparse_frames:
+                in_range = np.logical_and(frame >= start, frame <= end)
+                clipped_adjusted_frame = frame[in_range] - start
+                dp[clipped_adjusted_frame] += 1
             return dp
         elif len(indices) == len(self.scan_shape) + 2:
             # The last two indices are frame indices
             frame_indices = indices[-2:]
             flat_frame_index = (frame_indices[0] * self.frame_shape[1] +
                                 frame_indices[1])
-            return np.count_nonzero(sparse_frame == flat_frame_index)
+            return sum(flat_frame_index in frame for frame in sparse_frames)
 
         max_length = len(self.shape) + 1
         raise ValueError(f'0 < len(indices) < {max_length} is required')

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -515,7 +515,10 @@ ElectronCountedData electronCount(Reader* reader, const float darkReference[],
                                   Dimensions2D scanDimensions, bool verbose)
 {
   // This is where we will save the electron events as the calculated
-  Events events;
+  // Outer vector is scan position, middle vector is a frame at that
+  // scan position, and inner vector is the electron counted data for
+  // the frame.
+  std::vector<std::vector<std::vector<uint32_t>>> events;
   // We need an array of mutexes to protect updates for each event vector for a
   // given position, as we may have muliple frames per location.
   std::unique_ptr<std::mutex[]> positionMutexes;
@@ -566,8 +569,7 @@ ElectronCountedData electronCount(Reader* reader, const float darkReference[],
       auto& mutex = positionMutexes[position];
       std::unique_lock<std::mutex> positionLock(mutex);
       // Append the events
-      eventsForPosition.insert(eventsForPosition.end(), frameEvents.begin(),
-                               frameEvents.end());
+      eventsForPosition.push_back(std::move(frameEvents));
     }
   };
 
@@ -690,7 +692,8 @@ ElectronCountedData electronCount(Reader* reader, const float darkReference[],
       auto frameEvents = electronCount<FrameType, dark>(
         frame, frameDimensions, darkReference, backgroundThreshold,
         xRayThreshold, gain);
-      events[b.header.imageNumbers[j]] = frameEvents;
+      auto position = b.header.imageNumbers[j];
+      events[position].push_back(std::move(frameEvents));
     }
   }
 
@@ -702,7 +705,15 @@ ElectronCountedData electronCount(Reader* reader, const float darkReference[],
 #endif
 
   ElectronCountedData ret;
-  ret.data = events;
+  // We need at least the number of scan positions, potentially more.
+  // Go ahead and reserve the number of scan positions.
+  ret.data.reserve(numberOfScanPositions);
+  for (int position = 0; position < events.size(); ++position) {
+    for (int i = 0; i < events[position].size(); ++i) {
+      ret.data.push_back(std::move(events[position][i]));
+      ret.scanPositions.push_back(position);
+    }
+  }
   ret.scanDimensions = scanDimensions;
   ret.frameDimensions = frameSize;
 

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -7,15 +7,16 @@ namespace stempy {
 
 class SectorStreamThreadedReader;
 
+using Events = std::vector<std::vector<uint32_t>>;
+
 struct ElectronCountedData
 {
-  std::vector<std::vector<uint32_t>> data;
+  Events data;
+  std::vector<uint32_t> scanPositions;
 
   Dimensions2D scanDimensions = { 0, 0 };
   Dimensions2D frameDimensions = { 0, 0 };
 };
-
-using Events = std::vector<std::vector<uint32_t>>;
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,

--- a/tests/test_sparse_array.py
+++ b/tests/test_sparse_array.py
@@ -348,6 +348,126 @@ def test_round_trip_hdf5(sparse_array_small):
         assert np.array_equal(a, b)
 
 
+def test_multiple_frames_per_scan_position():
+    # Some simple tests where we know the answer for multiple frames
+    # per scan position.
+    data = np.empty(4, dtype=object)
+    data[0] = np.array([0])
+    data[1] = np.array([0, 2])
+    data[2] = np.array([0])
+    data[3] = np.array([0, 1])
+    kwargs = {
+        'data': data,
+        'scan_shape': (2, 1),
+        'frame_shape': (2, 2),
+        'scan_positions': (0, 0, 1, 1),
+        'sparse_slicing': False,
+        'allow_full_expand': True,
+    }
+    array = SparseArray(**kwargs)
+
+    # These are our expected expansions of the positions
+    position_zero = np.array([[2, 0], [1, 0]])
+    position_one = np.array([[2, 1], [0, 0]])
+
+    # Test full array
+    full = array[:]
+    assert full.shape == (2, 1, 2, 2)
+    assert np.array_equal(full[0, 0], position_zero)
+    assert np.array_equal(full[1, 0], position_one)
+
+    # Test dense slicing
+    assert array[0].shape == (1, 2, 2)
+    assert np.array_equal(array[0, 0], position_zero)
+    assert np.array_equal(array[1, 0], position_one)
+
+    # Test sparse slicing
+    array.sparse_slicing = True
+
+    # Scan slicing
+    assert isinstance(array[0], SparseArray)
+    assert isinstance(array[:, 0], SparseArray)
+    assert array[0].shape == full[0].shape
+    assert array[:, 0].shape == full[:, 0].shape
+    assert np.array_equal(array[0][0], array[0, 0])
+    assert np.array_equal(array[1][0], array[1, 0])
+    assert np.array_equal(array[0:][0][0], array[0, 0])
+    assert np.array_equal(array[1:][0][0], array[1, 0])
+    assert np.array_equal(array[:, 0][0], array[0, 0])
+    assert np.array_equal(array[:, 0][1], array[1, 0])
+    assert np.array_equal(array[::2, 0][0], full[::2, 0][0])
+
+    # Frame slicing
+    assert isinstance(array[:, :, 0], SparseArray)
+    assert array[:, :, 0].shape == full[:, :, 0].shape
+    assert array[:, :, 0, 1].shape == full[:, :, 0, 1].shape
+    assert np.array_equal(array[:, :, 0][0, 0], full[:, :, 0][0, 0])
+    assert np.array_equal(array[:, :, 0][1, 0], full[:, :, 0][1, 0])
+    assert np.array_equal(array[:, :, 0, 1][0, 0], full[:, :, 0, 1][0, 0])
+    assert np.array_equal(array[:, :, 0, 1:][0, 0], full[:, :, 0, 1:][0, 0])
+    assert np.array_equal(array[:, :, 0:2, 0:2][0, 0],
+                          full[:, :, 0:2, 0:2][0, 0])
+    assert np.array_equal(array[:, :, 0:2, 0:2][1, 0],
+                          full[:, :, 0:2, 0:2][1, 0])
+    assert np.array_equal(array[0, :, :, 0][0], full[0, :, :, 0][0])
+    assert np.array_equal(array[0, :, :, 1][0], full[0, :, :, 1][0])
+    assert np.array_equal(array[0, :, 0:2, 0:2][0], full[0, :, 0:2, 0:2][0])
+    assert np.array_equal(array[1, :, 0:2, 0:2][0], full[1, :, 0:2, 0:2][0])
+    assert np.array_equal(array[0, 0, ::2, ::2], full[0, 0, ::2, ::2])
+    assert np.array_equal(array[1, 0, ::2, ::2], full[1, 0, ::2, ::2])
+
+    # Test arithmetic
+    axis = (0, 1)
+    assert np.array_equal(array.sum(axis=axis), [[4, 1], [1, 0]])
+    assert np.array_equal(array.max(axis=axis), [[2, 1], [1, 0]])
+    assert np.array_equal(array.min(axis=axis), [[2, 0], [0, 0]])
+    assert np.array_equal(array.mean(axis=axis), [[2, 0.5], [0.5, 0]])
+
+    # Test frame binning
+    data = np.empty(4, dtype=object)
+    data[0] = np.array([0, 2, 3, 5, 9])
+    data[1] = np.array([15])
+    data[2] = np.array([7])
+    data[3] = np.array([], dtype=int)
+
+    kwargs = {
+        'data': data,
+        'scan_shape': (2, 1),
+        'frame_shape': (4, 4),
+        'scan_positions': (0, 0, 1, 1),
+        'sparse_slicing': False,
+    }
+    test_bin_frames_array = SparseArray(**kwargs)
+    binned = test_bin_frames_array.bin_frames(2)
+
+    assert binned.shape == (2, 1, 2, 2)
+    assert np.array_equal(binned[0, 0], [[2, 2], [1, 1]])
+    assert np.array_equal(binned[1, 0], [[0, 1], [0, 0]])
+
+    # Test scan binning
+    data = np.empty(16, dtype=object)
+    data[0] = np.array([0, 1])
+    data[1] = np.array([0, 2])
+    # Automate the rest of them...
+    for i in range(2, 16):
+        data[i] = np.array([i % 4])
+
+    kwargs = {
+        'data': data,
+        'scan_shape': (4, 4),
+        'frame_shape': (2, 2),
+        'sparse_slicing': False,
+    }
+    test_bin_scans_array = SparseArray(**kwargs)
+    binned = test_bin_scans_array.bin_scans(2)
+
+    assert binned.shape == (2, 2, 2, 2)
+    assert np.array_equal(binned[0, 0], [[3, 2], [1, 0]])
+    assert np.array_equal(binned[0, 1], [[0, 0], [2, 2]])
+    assert np.array_equal(binned[1, 0], [[2, 2], [0, 0]])
+    assert np.array_equal(binned[1, 1], [[0, 0], [2, 2]])
+
+
 # Test binning until this number
 TEST_BINNING_UNTIL = 33
 


### PR DESCRIPTION
Previously, in the electron counting, we would combine two sparse arrays
if they had the same scan positions. Now, we are modifying this so that
the sparse arrays are kept separately per frame, and duplicates are no
longer allowed in a single sparse array.

The ElectronCountedData struct now has a scanPositions vector to indicate
which scan a sparse array belongs to, since the data vector no longer
matches the size of the scan.

This also updates the SparseArray class to perform faster (and correct)
arithmetic and expanding based upon the new way that the sparse data is
formatted.

I have tested the electron counting with a dataset that has two frames
per scan position, and for fully expanding the output sparse array, I
received the same result before and after these changes, which indicates
that it is hopefully working correctly.

An extensive test was also added which tests most pieces of using a
SparseArray where some scan positions have multiple frames.

This will probably have some minor merge conflicts with #226.

Fixes: #208