### PR TITLE
Fix create_stem_images() crash with v2 data

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -258,9 +258,10 @@ ElectronCountedDataPyArray electronCount(
 // Explicitly instantiate version for py::array_t
 template std::vector<STEMImage> createSTEMImages(
   const std::vector<py::array_t<uint32_t>>& sparseData,
+  const std::vector<uint32_t>& scanPositions,
   const std::vector<int>& innerRadii, const std::vector<int>& outerRadii,
   Dimensions2D scanDimensions, Dimensions2D frameDimensions,
-  Coordinates2D center, int frameOffset);
+  Coordinates2D center);
 
 } // namespace stempy
 
@@ -269,8 +270,9 @@ vector<STEMImage> createSTEMImages(const ElectronCountedDataPyArray& array,
                                    const vector<int>& outerRadii,
                                    Coordinates2D coords)
 {
-  return createSTEMImages(array.data, innerRadii, outerRadii,
-                          array.scanDimensions, array.frameDimensions, coords);
+  return createSTEMImages(array.data, array.scanPositions, innerRadii,
+                          outerRadii, array.scanDimensions,
+                          array.frameDimensions, coords);
 }
 
 template <typename... Params>
@@ -447,8 +449,9 @@ PYBIND11_MODULE(_image, m)
     py::call_guard<py::gil_scoped_release>());
   m.def("create_stem_images",
         (vector<STEMImage>(*)(const std::vector<py::array_t<uint32_t>>&,
-                              const vector<int>&, const vector<int>&,
-                              Dimensions2D, Dimensions2D, Coordinates2D, int)) &
+                              const vector<uint32_t>&, const vector<int>&,
+                              const vector<int>&, Dimensions2D, Dimensions2D,
+                              Coordinates2D)) &
           createSTEMImages,
         py::call_guard<py::gil_scoped_release>());
   m.def(

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -337,7 +337,7 @@ vector<STEMImage> createSTEMImages(const ElectronCountedData& data,
                                    const vector<int>& outerRadii,
                                    Coordinates2D center)
 {
-  return createSTEMImages(data.data, innerRadii, outerRadii,
+  return createSTEMImages(data.data, data.scanPositions, innerRadii, outerRadii,
                           data.scanDimensions, data.frameDimensions, center);
 }
 

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -64,8 +64,8 @@ namespace stempy {
   // Create STEM Images from sparse data
   template <typename T>
   void calculateSTEMValuesSparse(const std::vector<T>& sparseData,
-                                 uint16_t* mask, STEMImage& image,
-                                 int frameOffset)
+                                 const std::vector<uint32_t>& scanPositions,
+                                 uint16_t* mask, STEMImage& image)
   {
     for (unsigned i = 0; i < sparseData.size(); ++i) {
       uint64_t values = 0;
@@ -75,16 +75,19 @@ namespace stempy {
         auto pos = sparseData[i].data()[j];
         values += mask[pos];
       }
-      image.data.get()[i + frameOffset] = values;
+
+      auto pos = scanPositions[i];
+      image.data.get()[pos] += values;
     }
   }
 
   template <typename T>
   std::vector<STEMImage> createSTEMImages(
-    const std::vector<T>& sparseData, const std::vector<int>& innerRadii,
-    const std::vector<int>& outerRadii, Dimensions2D scanDimensions = { 0, 0 },
-    Dimensions2D frameDimensions = { 0, 0 }, Coordinates2D center = { -1, -1 },
-    int frameOffset = 0)
+    const std::vector<T>& sparseData,
+    const std::vector<uint32_t>& scanPositions,
+    const std::vector<int>& innerRadii, const std::vector<int>& outerRadii,
+    Dimensions2D scanDimensions = { 0, 0 },
+    Dimensions2D frameDimensions = { 0, 0 }, Coordinates2D center = { -1, -1 })
   {
     if (innerRadii.empty() || outerRadii.empty()) {
       std::ostringstream msg;
@@ -107,7 +110,7 @@ namespace stempy {
     }
 
     for (size_t i = 0; i < masks.size(); ++i)
-      calculateSTEMValuesSparse(sparseData, masks[i], images[i], frameOffset);
+      calculateSTEMValuesSparse(sparseData, scanPositions, masks[i], images[i]);
 
     for (auto* p : masks)
       delete[] p;


### PR DESCRIPTION
This fixes a crash that would occur if `create_stem_images()` was
called using v2 data, and there were more than one frame per scan
position.

Internally, it does so by moving around an additional array of scan
positions to keep track of which frame belongs to which scan position.

The python API remains unchanged.

Fixes: #243