### PR TITLE
Fix sparse slicing performance in SparseArray

### DIFF
--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -770,9 +770,9 @@ class SparseArray:
             # Sort them so we don't undo the new ordering which is already
             # a part of the new_frames.
             new_scan_positions = self.scan_positions[np.sort(to_keep)]
-            for i in range(len(positions_to_keep)):
-                while i not in new_scan_positions:
-                    new_scan_positions[new_scan_positions > i] -= 1
+            unique = np.unique(new_scan_positions)
+            for i, x in enumerate(unique):
+                new_scan_positions[new_scan_positions == x] = i
         else:
             new_scan_shape = self.scan_shape
             new_frames = self.data


### PR DESCRIPTION
When large scan indices were being used for sparse slicing, these loops
were taking way too long to regenerate the indices of the scan positions.
For very large scans, it could take over a second (or even much longer)
to index into the sparse array with large scan positions.

This change results in significantly faster slicing. For one example
where it would take over 1 second to perform the sparse slicing, it
now takes 4 microseconds.

Fixes: #246.