### PR TITLE
Refactor SparseArray and methods to data version 3

### DIFF
--- a/python/stempy/io/compatibility.py
+++ b/python/stempy/io/compatibility.py
@@ -5,13 +5,23 @@ def convert_data_format(data, scan_positions, scan_shape, frame_shape,
                         from_version, to_version):
     """Convert the data and return new (data, scan_positions) as a tuple"""
     if from_version == to_version:
-        return data, scan_positions
+        if to_version < 3:
+            return data, scan_positions
+        else:
+            return data
 
-    if from_version == 1 and to_version == 2:
-        return convert_data_v1_to_v2(data, scan_positions, scan_shape)
+    func_map = {
+        (1, 2): convert_data_v1_to_v2,
+        (1, 3): convert_data_v1_to_v3,
+        (2, 3): convert_data_v2_to_v3,
+    }
 
-    msg = f'Conversion not implemented: {from_version} => {to_version}'
-    raise NotImplementedError(msg)
+    key = (from_version, to_version)
+    if key not in func_map:
+        msg = f'Conversion not implemented: {from_version} => {to_version}'
+        raise NotImplementedError(msg)
+
+    return func_map[key](data, scan_positions, scan_shape)
 
 
 def convert_data_v1_to_v2(data, scan_positions, scan_shape):
@@ -51,6 +61,37 @@ def convert_data_v1_to_v2(data, scan_positions, scan_shape):
         scan_positions = new_scan_positions
 
     return ret, scan_positions
+
+
+def convert_data_v1_to_v3(data, scan_positions, scan_shape):
+    data, scan_positions = convert_data_v1_to_v2(data, scan_positions,
+                                                 scan_shape)
+    return convert_data_v2_to_v3(data, scan_positions, scan_shape)
+
+
+def convert_data_v2_to_v3(data, scan_positions, scan_shape):
+    # Get some stats about the data
+    num_scans = np.prod(scan_shape)
+    unique, counts = np.unique(scan_positions, return_counts=True)
+    frames_per_scan = np.max(counts)
+
+    result = np.empty((num_scans, frames_per_scan), dtype=object)
+
+    # Now set all of the data in their new locations
+    for datum, pos in zip(data, scan_positions):
+        current = result[pos]
+        for i in range(frames_per_scan):
+            if current[i] is None:
+                current[i] = datum
+                break
+
+    # Now fill in any remaining Nones with empty arrays
+    for scan_frames in result:
+        for i in range(frames_per_scan):
+            if scan_frames[i] is None:
+                scan_frames[i] = np.array([], dtype=np.uint32)
+
+    return result
 
 
 def is_data_v1_format(data, scan_shape):

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -7,7 +7,7 @@ namespace stempy {
 
 class SectorStreamThreadedReader;
 
-using Events = std::vector<std::vector<uint32_t>>;
+using Events = std::vector<std::vector<std::vector<uint32_t>>>;
 
 struct ElectronCountedMetadata
 {
@@ -30,7 +30,6 @@ struct ElectronCountedMetadata
 struct ElectronCountedData
 {
   Events data;
-  std::vector<uint32_t> scanPositions;
 
   ElectronCountedMetadata metadata;
   Dimensions2D scanDimensions = { 0, 0 };
@@ -128,7 +127,7 @@ void initMpiWorldRank(int& worldSize, int& rank);
 int getSampleBlocksPerRank(int worldSize, int rank,
                            int thresholdNumberOfBlocks);
 void gatherBlocks(int worldSize, int rank, std::vector<Block>& blocks);
-void gatherEvents(int worldSize, int rank, std::vector<Events>& events);
+void gatherEvents(int worldSize, int rank, Events& events);
 void broadcastThresholds(double& background, double& xRay);
 
 #endif

--- a/stempy/electron_mpi.cpp
+++ b/stempy/electron_mpi.cpp
@@ -33,8 +33,7 @@ void serializeBlocks(std::vector<Block>& blocks, std::ostream* stream)
   archive(blocks);
 }
 
-void receivePartialMap(std::vector<Events>& events,
-                       std::vector<char>& recvBuffer)
+void receivePartialMap(Events& events, std::vector<char>& recvBuffer)
 {
   MPI_Status status;
   // Probe for an incoming message from rank zero
@@ -67,7 +66,7 @@ void receivePartialMap(std::vector<Events>& events,
   }
 }
 
-void sendPartialMap(std::vector<Events>& events)
+void sendPartialMap(Events& events)
 {
   // Create a partial map of electron events
   SparseEventMap partialEventMap;
@@ -88,8 +87,7 @@ void sendPartialMap(std::vector<Events>& events)
            MPI_BYTE, 0, 0, MPI_COMM_WORLD);
 }
 
-void gatherEvents(int worldSize, int rank,
-                 std::vector<Events>& events)
+void gatherEvents(int worldSize, int rank, Events& events)
 {
   // Now the final gather!
   // It would be nice to use a gather here, but the displacement values can

--- a/stempy/image.cpp
+++ b/stempy/image.cpp
@@ -337,7 +337,7 @@ vector<STEMImage> createSTEMImages(const ElectronCountedData& data,
                                    const vector<int>& outerRadii,
                                    Coordinates2D center)
 {
-  return createSTEMImages(data.data, data.scanPositions, innerRadii, outerRadii,
+  return createSTEMImages(data.data, innerRadii, outerRadii,
                           data.scanDimensions, data.frameDimensions, center);
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ DATA_URLS = {
     'electron_small': 'https://data.kitware.com/api/v1/file/6065f00d2fa25629b93bdabe/download',  # noqa
     'electron_large': 'https://data.kitware.com/api/v1/file/6065f2792fa25629b93c0303/download',  # noqa
     'cropped_multi_frames_v1': 'https://data.kitware.com/api/v1/file/623119814acac99f4261aa59/download',  # noqa
+    'cropped_multi_frames_v2': 'https://data.kitware.com/api/v1/file/6244e9944acac99f424743df/download',  # noqa
+    'cropped_multi_frames_v3': 'https://data.kitware.com/api/v1/file/624601cd4acac99f425c73f6/download',  # noqa
 }
 
 DATA_RESPONSES = {}
@@ -44,6 +46,16 @@ def electron_data_large():
 @pytest.fixture
 def cropped_multi_frames_data_v1():
     return io_object('cropped_multi_frames_v1')
+
+
+@pytest.fixture
+def cropped_multi_frames_data_v2():
+    return io_object('cropped_multi_frames_v2')
+
+
+@pytest.fixture
+def cropped_multi_frames_data_v3():
+    return io_object('cropped_multi_frames_v3')
 
 
 # SparseArray fixtures
@@ -85,3 +97,13 @@ def full_array_small(sparse_array_small):
 @pytest.fixture
 def cropped_multi_frames_v1(cropped_multi_frames_data_v1):
     return SparseArray.from_hdf5(cropped_multi_frames_data_v1)
+
+
+@pytest.fixture
+def cropped_multi_frames_v2(cropped_multi_frames_data_v2):
+    return SparseArray.from_hdf5(cropped_multi_frames_data_v2)
+
+
+@pytest.fixture
+def cropped_multi_frames_v3(cropped_multi_frames_data_v3):
+    return SparseArray.from_hdf5(cropped_multi_frames_data_v3)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,14 +96,14 @@ def full_array_small(sparse_array_small):
 
 @pytest.fixture
 def cropped_multi_frames_v1(cropped_multi_frames_data_v1):
-    return SparseArray.from_hdf5(cropped_multi_frames_data_v1)
+    return SparseArray.from_hdf5(cropped_multi_frames_data_v1, dtype=np.uint16)
 
 
 @pytest.fixture
 def cropped_multi_frames_v2(cropped_multi_frames_data_v2):
-    return SparseArray.from_hdf5(cropped_multi_frames_data_v2)
+    return SparseArray.from_hdf5(cropped_multi_frames_data_v2, dtype=np.uint16)
 
 
 @pytest.fixture
 def cropped_multi_frames_v3(cropped_multi_frames_data_v3):
-    return SparseArray.from_hdf5(cropped_multi_frames_data_v3)
+    return SparseArray.from_hdf5(cropped_multi_frames_data_v3, dtype=np.uint16)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -7,16 +7,15 @@ from stempy.io.sparse_array import SparseArray
 def test_com_sparse(sparse_array_small, full_array_small):
     # Do a basic test of com_sparse() with multiple frames per scan
     # position.
-    data = np.empty(4, dtype=object)
-    data[0] = np.array([0])
-    data[1] = np.array([3])
-    data[2] = np.array([0])
-    data[3] = np.array([0, 1, 2])
+    data = np.empty((2, 2), dtype=object)
+    data[0][0] = np.array([0])
+    data[0][1] = np.array([3])
+    data[1][0] = np.array([0])
+    data[1][1] = np.array([0, 1, 2])
     kwargs = {
         'data': data,
         'scan_shape': (2, 1),
         'frame_shape': (2, 2),
-        'scan_positions': (0, 0, 1, 1),
     }
     array = SparseArray(**kwargs)
 


### PR DESCRIPTION
Version 3 of the SparseArray and electron counting methods changes the
data shape from a flat array of sparse frames to a 2D array, where the
first dimension is the scan position, and the second dimension is the
index of a frame at that scan position. This removes the need for the
`scan_positions` array (previously used to indicate which scan position
each sparse frame corresponded to).

Now, the data array passed to the SparseArray must either have a shape
of `(num_scans, frames_per_scan)` or just `(num_scans,)` (where one frame
per scan will be assumed, and the shape will be changed automatically to
`(num_scans, 1)`. Validation is performed to ensure this is the case, or
an exception will be raised.

This simplifies a lot of the logic involving multiple frames per scan
position, and completely removes the need for manipulating the scan
positions array that the SparseArray previously held.

For writing to HDF5, it appears that h5py does not allow a 2D array of
variable length arrays to be written (see h5py/h5py#876), so we must
flatten it to a 1D array for HDF5 storage. The scan shape allows the
2D array to be re-created on loading.

Backwards compatibility has been maintained so that the SparseArray class
can load in HDF5 files saved in versions 1, 2, or 3 and correctly convert
them to version 3 upon loading. Tests have been added to ensure this is
the case.