### PR TITLE
Add row dark algorithm to electron counting

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -60,6 +60,9 @@ struct ElectronCountOptionsClassicPy
   double xRayThreshold = DBL_MAX;
   py::array_t<float> gain;
   Dimensions2D scanDimensions = { 0, 0 };
+  bool applyRowDarkSubtraction = false;
+  float optimizedMean = 0;
+  bool applyRowDarkUseMean = true;
 
   ElectronCountOptionsClassic toCpp() const
   {
@@ -70,6 +73,9 @@ struct ElectronCountOptionsClassicPy
     options.backgroundThreshold = this->backgroundThreshold;
     options.xRayThreshold = this->xRayThreshold;
     options.scanDimensions = this->scanDimensions;
+    options.applyRowDarkSubtraction = this->applyRowDarkSubtraction;
+    options.optimizedMean = this->optimizedMean;
+    options.applyRowDarkUseMean = this->applyRowDarkUseMean;
 
     if (this->darkReference.size() > 1) {
       py::buffer_info buf = this->darkReference.request();
@@ -95,6 +101,8 @@ struct ElectronCountOptionsPy
   py::array_t<float> gain;
   Dimensions2D scanDimensions = { 0, 0 };
   bool verbose = false;
+  bool applyRowDarkSubtraction = false;
+  bool applyRowDarkUseMean = true;
 
   ElectronCountOptions toCpp() const
   {
@@ -109,6 +117,8 @@ struct ElectronCountOptionsPy
     options.xRayThresholdNSigma = this->xRayThresholdNSigma;
     options.scanDimensions = this->scanDimensions;
     options.verbose = this->verbose;
+    options.applyRowDarkSubtraction = this->applyRowDarkSubtraction;
+    options.applyRowDarkUseMean = this->applyRowDarkUseMean;
 
     if (this->darkReference.size() > 1) {
       py::buffer_info buf = this->darkReference.request();
@@ -423,7 +433,13 @@ PYBIND11_MODULE(_image, m)
                    &ElectronCountOptionsClassicPy::xRayThreshold)
     .def_readwrite("gain", &ElectronCountOptionsClassicPy::gain)
     .def_readwrite("scan_dimensions",
-                   &ElectronCountOptionsClassicPy::scanDimensions);
+                   &ElectronCountOptionsClassicPy::scanDimensions)
+    .def_readwrite("apply_row_dark_subtraction",
+                   &ElectronCountOptionsClassicPy::applyRowDarkSubtraction)
+    .def_readwrite("optimized_mean",
+                   &ElectronCountOptionsClassicPy::optimizedMean)
+    .def_readwrite("apply_row_dark_use_mean",
+                   &ElectronCountOptionsClassicPy::applyRowDarkUseMean);
 
   py::class_<ElectronCountOptionsPy>(m, "ElectronCountOptions",
                                      py::buffer_protocol())
@@ -439,7 +455,11 @@ PYBIND11_MODULE(_image, m)
                    &ElectronCountOptionsPy::xRayThresholdNSigma)
     .def_readwrite("gain", &ElectronCountOptionsPy::gain)
     .def_readwrite("scan_dimensions", &ElectronCountOptionsPy::scanDimensions)
-    .def_readwrite("verbose", &ElectronCountOptionsPy::verbose);
+    .def_readwrite("verbose", &ElectronCountOptionsPy::verbose)
+    .def_readwrite("apply_row_dark_subtraction",
+                   &ElectronCountOptionsPy::applyRowDarkSubtraction)
+    .def_readwrite("apply_row_dark_use_mean",
+                   &ElectronCountOptionsPy::applyRowDarkUseMean);
 
   m.def("electron_count",
         (ElectronCountedDataPyArray(*)(StreamReader::iterator,

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -195,7 +195,8 @@ def calculate_average(reader):
 def electron_count(reader, darkreference=None, number_of_samples=40,
                    background_threshold_n_sigma=4, xray_threshold_n_sigma=10,
                    threshold_num_blocks=1, scan_dimensions=(0, 0),
-                   verbose=False, gain=None):
+                   verbose=False, gain=None, apply_row_dark=False,
+                   apply_row_dark_use_mean=True):
     """Generate a list of coordinates of electron hits.
 
     :param reader: the file reader that has already opened the data.
@@ -223,6 +224,12 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
     :type verbose: bool
     :param gain: the gain mask to apply. Must match the frame dimensions
     :type gain: numpy.ndarray (2D)
+    :param apply_row_dark: whether to apply the row dark algorithm to the data.
+    :type apply_row_dark: bool
+    :param apply_row_dark_use_mean: whether to use mean (if True) or median
+                                    (if False) in the row dark algorith. Only
+                                    applicable if apply_row_dark is True.
+    :param apply_row_dark_use_mean: bool
 
     :return: the coordinates of the electron hits for each frame.
     :rtype: SparseArray
@@ -249,6 +256,8 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         options.gain = gain
         options.scan_dimensions = scan_dimensions
         options.verbose = verbose
+        options.apply_row_dark_subtraction = apply_row_dark
+        options.apply_row_dark_use_mean = apply_row_dark_use_mean
 
         data = _image.electron_count(reader, options)
     else:
@@ -309,6 +318,9 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         options.x_ray_threshold = xray_threshold
         options.gain = gain
         options.scan_dimensions = scan_dimensions
+        options.apply_row_dark_subtraction = apply_row_dark
+        options.optimized_mean = res.optimized_mean
+        options.apply_row_dark_use_mean = apply_row_dark_use_mean
 
         data = _image.electron_count(reader.begin(), reader.end(), options)
 

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -239,22 +239,18 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
 
     # Special case for threaded reader
     if isinstance(reader, (SectorThreadedReader, SectorThreadedMultiPassReader)):
-        args = [reader]
+        options = _image.ElectronCountOptions()
 
-        if darkreference is not None:
-            args = args + [darkreference]
+        options.dark_reference = darkreference
+        options.threshold_number_of_blocks = threshold_num_blocks
+        options.number_of_samples = number_of_samples
+        options.background_threshold_n_sigma = background_threshold_n_sigma
+        options.x_ray_threshold_n_sigma = xray_threshold_n_sigma
+        options.gain = gain
+        options.scan_dimensions = scan_dimensions
+        options.verbose = verbose
 
-        # Now add the other args
-        args = args + [threshold_num_blocks, number_of_samples,
-                       background_threshold_n_sigma, xray_threshold_n_sigma]
-
-        # add the gain arg if we have been given one.
-        if gain is not None:
-            args.append(gain)
-
-        args = args + [scan_dimensions, verbose]
-
-        data = _image.electron_count(*args)
+        data = _image.electron_count(reader, options)
     else:
         deprecation_message = (
             'Using a reader in electron_count() that is not a '
@@ -267,7 +263,6 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         blocks = []
         for i in range(threshold_num_blocks):
             blocks.append(next(reader))
-
 
         if darkreference is not None and hasattr(darkreference, '_image'):
             darkreference = darkreference._image
@@ -306,19 +301,16 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         # Reset the reader
         reader.reset()
 
-        args = [reader.begin(), reader.end()]
+        options = _image.ElectronCountOptionsClassic()
 
-        if darkreference is not None:
-            args.append(darkreference)
+        # Do we need to convert this to a numpy array?
+        options.dark_reference = darkreference
+        options.background_threshold = background_threshold
+        options.x_ray_threshold = xray_threshold
+        options.gain = gain
+        options.scan_dimensions = scan_dimensions
 
-        args = args + [background_threshold, xray_threshold]
-
-        if gain is not None:
-            args.append(gain)
-
-        args = args + [scan_dimensions]
-
-        data = _image.electron_count(*args)
+        data = _image.electron_count(reader.begin(), reader.end(), options)
 
     # Convert to numpy array
     num_scans = len(data.data)

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -545,7 +545,7 @@ std::vector<uint32_t> electronCount(
       static_if<dark>(
         [&]() { frame[j] -= static_cast<FrameType>(darkReference[j]); })();
 
-      if (not std::is_integral<FrameType>::value) {
+      if (!std::is_integral<FrameType>::value) {
         frame[j] *= gain[j];
       }
 

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -368,7 +368,7 @@ ElectronCountedData electronCount(
         if (std::is_integral<FrameType>::value) {
           frame[j] -= darkReference[j];
         } else {
-          frame[j] = frame[i] * gain[i] - darkReference[j];
+          frame[j] = frame[j] * gain[j] - darkReference[j];
         }
         // Threshold the electron events
         if (frame[j] <= backgroundThreshold || frame[j] >= xRayThreshold) {

--- a/stempy/electron.cpp
+++ b/stempy/electron.cpp
@@ -252,8 +252,8 @@ void applyRowDark(std::vector<FrameType>& frame, Dimensions2D frameDimensions,
   // Function to compute the mean for a given range in the frame
   using FrameVecType = std::vector<FrameType>;
   auto mean = [](const FrameVecType& frame, size_t start, size_t stop) {
-    return std::accumulate(frame.begin() + start, frame.begin() + stop, 0.0) /
-           static_cast<double>(stop - start);
+    return std::accumulate(frame.begin() + start, frame.begin() + stop, 0.0f) /
+           static_cast<float>(stop - start);
   };
 
   // Function to compute the median for a given range in the frame
@@ -264,15 +264,15 @@ void applyRowDark(std::vector<FrameType>& frame, Dimensions2D frameDimensions,
     std::nth_element(v.begin(), v.begin() + n, v.end());
     if (v.size() & 1) {
       // The size is odd
-      return static_cast<double>(v[n]);
+      return static_cast<float>(v[n]);
     } else {
       // The size is even. Need to average the middle two.
       auto it = max_element(v.begin(), v.begin() + n);
-      return (*it + v[n]) / static_cast<double>(2.0);
+      return (*it + v[n]) / 2.0f;
     }
   };
 
-  double (*statFunc)(const FrameVecType&, size_t, size_t);
+  float (*statFunc)(const FrameVecType&, size_t, size_t);
   if (useMean) {
     statFunc = mean;
   } else {

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -45,6 +45,9 @@ struct ElectronCountOptionsClassic
   double xRayThreshold = DBL_MAX;
   float* gain = nullptr;
   Dimensions2D scanDimensions = { 0, 0 };
+  bool applyRowDarkSubtraction = false;
+  float optimizedMean = 0;
+  bool applyRowDarkUseMean = true;
 };
 
 struct ElectronCountOptions
@@ -57,6 +60,8 @@ struct ElectronCountOptions
   float* gain = nullptr;
   Dimensions2D scanDimensions = { 0, 0 };
   bool verbose = false;
+  bool applyRowDarkSubtraction = false;
+  bool applyRowDarkUseMean = true;
 };
 
 template <typename InputIt>
@@ -74,7 +79,8 @@ int getSampleBlocksPerRank(int worldSize, int rank,
                            int thresholdNumberOfBlocks);
 void gatherBlocks(int worldSize, int rank, std::vector<Block>& blocks);
 void gatherEvents(int worldSize, int rank, Events& events);
-void broadcastThresholds(double& background, double& xRay);
+void broadcastThresholds(double& background, double& xRay,
+                         double& optimizedMean);
 
 #endif
 }

--- a/stempy/electron.h
+++ b/stempy/electron.h
@@ -1,6 +1,8 @@
 #ifndef STEMPY_ELECTRON_H_
 #define STEMPY_ELECTRON_H_
 
+#include <cfloat>
+
 #include "image.h"
 
 namespace stempy {
@@ -36,90 +38,34 @@ struct ElectronCountedData
   Dimensions2D frameDimensions = { 0, 0 };
 };
 
-template <typename InputIt>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<float>& darkreference,
-                                  double backgroundThreshold,
-                                  double xRayThreshold,
-                                  Dimensions2D scanDimensions = { 0, 0 });
+struct ElectronCountOptionsClassic
+{
+  float* darkReference = nullptr;
+  double backgroundThreshold = DBL_MIN;
+  double xRayThreshold = DBL_MAX;
+  float* gain = nullptr;
+  Dimensions2D scanDimensions = { 0, 0 };
+};
+
+struct ElectronCountOptions
+{
+  float* darkReference = nullptr;
+  int thresholdNumberOfBlocks = 1;
+  int numberOfSamples = 20;
+  double backgroundThresholdNSigma = 4;
+  double xRayThresholdNSigma = 10;
+  float* gain = nullptr;
+  Dimensions2D scanDimensions = { 0, 0 };
+  bool verbose = false;
+};
 
 template <typename InputIt>
 ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const float darkreference[],
-                                  double backgroundThreshold,
-                                  double xRayThreshold,
-                                  Dimensions2D scanDimensions = { 0, 0 });
-
-template <typename InputIt>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  Image<float>& darkreference,
-                                  double backgroundThreshold,
-                                  double xRayThreshold, const float gain[],
-                                  Dimensions2D scanDimensions = { 0, 0 });
-
-template <typename InputIt>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  const float darkreference[],
-                                  double backgroundThreshold,
-                                  double xRayThreshold, const float gain[],
-                                  Dimensions2D scanDimensions = { 0, 0 });
-
-template <typename InputIt>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  double backgroundThreshold,
-                                  double xRayThreshold, const float gain[],
-                                  Dimensions2D scanDimensions = { 0, 0 });
-
-template <typename InputIt>
-ElectronCountedData electronCount(InputIt first, InputIt last,
-                                  double backgroundThreshold,
-                                  double xRayThreshold,
-                                  Dimensions2D scanDimensions = { 0, 0 });
+                                  const ElectronCountOptionsClassic& options);
 
 template <typename Reader>
-ElectronCountedData electronCount(Reader* reader, Image<float>& darkreference,
-                                  int thresholdNumberOfBlocks = 1,
-                                  int numberOfSamples = 20,
-                                  double backgroundThresholdNSigma = 4,
-                                  double xRayThresholdNSigma = 10,
-                                  Dimensions2D scanDimensions = { 0, 0 },
-                                  bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(Reader* reader, const float darkreference[],
-                                  int thresholdNumberOfBlocks = 1,
-                                  int numberOfSamples = 20,
-                                  double backgroundThresholdNSigma = 4,
-                                  double xRayThresholdNSigma = 10,
-                                  Dimensions2D scanDimensions = { 0, 0 },
-                                  bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, Image<float>& darkreference, int thresholdNumberOfBlocks = 1,
-  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10, const float gain[] = nullptr,
-  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, const float darkreference[], int thresholdNumberOfBlocks = 1,
-  int numberOfSamples = 20, double backgroundThresholdNSigma = 4,
-  double xRayThresholdNSigma = 10, const float gain[] = nullptr,
-  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
-  const float gain[] = nullptr, Dimensions2D scanDimensions = { 0, 0 },
-  bool verbose = false);
-
-template <typename Reader>
-ElectronCountedData electronCount(
-  Reader* reader, int thresholdNumberOfBlocks = 1, int numberOfSamples = 20,
-  double backgroundThresholdNSigma = 4, double xRayThresholdNSigma = 10,
-  Dimensions2D scanDimensions = { 0, 0 }, bool verbose = false);
+ElectronCountedData electronCount(Reader* reader,
+                                  const ElectronCountOptions& options);
 
 #ifdef USE_MPI
 

--- a/stempy/electron_mpi.cpp
+++ b/stempy/electron_mpi.cpp
@@ -173,9 +173,10 @@ void gatherBlocks(int worldSize, int rank, std::vector<Block>& blocks)
   }
 }
 
-void broadcastThresholds(double& background, double& xRay)
+void broadcastThresholds(double& background, double& xRay,
+                         double& optimizedMean)
 {
-  std::vector<double> thresholds = { background, xRay };
+  std::vector<double> thresholds = { background, xRay, optimizedMean };
 
   // Broadcast the thresholds
   MPI_Bcast(thresholds.data(), thresholds.size(), MPI_DOUBLE, 0,
@@ -183,6 +184,7 @@ void broadcastThresholds(double& background, double& xRay)
 
   background = thresholds[0];
   xRay = thresholds[1];
+  optimizedMean = thresholds[2];
 }
 
 int getSampleBlocksPerRank(int worldSize, int rank, int thresholdNumberOfBlocks)

--- a/stempy/electronthresholds.cpp
+++ b/stempy/electronthresholds.cpp
@@ -100,20 +100,21 @@ CalculateThresholdsResults<FrameType> calculateThresholds(
       // For now just use the index, the image number don't seem to work, in the
       // current data set. In the future we should be using the image number.
 
+      auto value = blockData[randomFrameIndex * numberOfPixels + j];
+
       // This will be evaluated a compile time.
       if (std::is_integral<FrameType>::value) {
-        auto value = blockData[randomFrameIndex * numberOfPixels + j];
         static_if<dark>(
           [&]() { value -= static_cast<int16_t>(darkReference[j]); })();
-        samples[i * numberOfPixels + j] = value;
       }
       // if not integral type then we know we have gain and need to multiple
       else {
-        auto value = blockData[randomFrameIndex * numberOfPixels + j] * gain[j];
         static_if<dark>(
           [&]() { value -= static_cast<float>(darkReference[j]); })();
-        samples[i * numberOfPixels + j] = value;
+        value *= gain[j];
       }
+
+      samples[i * numberOfPixels + j] = value;
     }
   }
 


### PR DESCRIPTION
This adds a row dark algorithm to the electron counting. The row dark algorithm is applied to each frame pixel like the following:

```python
frame[i] *= optimizedMean / statResult;
```

Where the `optimizedMean` is obtained from the electron threshold step, and the `statResult` is either the mean or the median of the half of the row that the frame pixel is in.

This also fixes a bug where we were applying the gain before dark subtraction, when it should be the other way around (dark subtraction then gain).

This also refactors the `electronCount()` methods so that there are significantly fewer template declarations to update, and the electron counting options are now placed in structs so that, from a maintainability standpoint, it is easier to add options in the future.

Fixes: #258