### PR TITLE
Fix binning scans with multiple frames per scan

### DIFF
--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -497,7 +497,8 @@ class SparseArray:
         all_positions_reshaped = all_positions.reshape(
             new_scan_shape[0], bin_factor, new_scan_shape[1], bin_factor)
 
-        new_data_shape = (np.prod(new_scan_shape), bin_factor**2)
+        new_data_shape = (np.prod(new_scan_shape),
+                          bin_factor**2 * self.num_frames_per_scan)
         new_data = np.empty(new_data_shape, dtype=object)
         for i in range(new_scan_shape[0]):
             for j in range(new_scan_shape[1]):

--- a/tests/test_sparse_array.py
+++ b/tests/test_sparse_array.py
@@ -463,15 +463,26 @@ def test_multiple_frames_per_scan_position():
         'scan_shape': (4, 4),
         'frame_shape': (2, 2),
         'sparse_slicing': False,
+        'allow_full_expand': True,
     }
     test_bin_scans_array = SparseArray(**kwargs)
     binned = test_bin_scans_array.bin_scans(2)
 
     assert binned.shape == (2, 2, 2, 2)
+    assert binned.num_frames_per_scan == 4
     assert np.array_equal(binned[0, 0], [[3, 2], [1, 0]])
     assert np.array_equal(binned[0, 1], [[0, 0], [2, 2]])
     assert np.array_equal(binned[1, 0], [[2, 2], [0, 0]])
     assert np.array_equal(binned[1, 1], [[0, 0], [2, 2]])
+
+    # Ensure we can bin again
+    binned_twice = binned.bin_scans(2)
+    assert binned_twice.shape == (1, 1, 2, 2)
+    assert binned_twice.num_frames_per_scan == 16
+
+    # Ensure binning 4x is equal to binning 2x twice
+    binned_4x = test_bin_scans_array.bin_scans(4)
+    assert np.array_equal(binned_4x[:], binned_twice[:])
 
 
 def test_data_conversion(cropped_multi_frames_v1, cropped_multi_frames_v2,


### PR DESCRIPTION
It would previously raise an exception, because some of the logic needs to
take into account the possibility of having multiple frames per scan.

This commit fixes the issue.

Fixes: #261