### PR TITLE
Fix com sparse parameters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,7 @@ def simulate_sparse_array():
     center = (30, 70)
     how_sparse = .8 # 0-1; larger is less electrons
     disk_size = 10 # disk radius in pixels
+    num_frames = 2
     
     YY, XX = np.mgrid[0:frame_size[0], 0:frame_size[1]]
     RR = np.sqrt((YY-center[1])**2 + (XX-center[0])**2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,22 +118,23 @@ def cropped_multi_frames_v3(cropped_multi_frames_data_v3):
     return SparseArray.from_hdf5(cropped_multi_frames_data_v3, dtype=np.uint16)
 
 @pytest.fixture
-def simulate_sparse_array(scan_size, frame_size, center, how_sparse, disk_size):
+def simulate_sparse_array():
+    
     """Make a ndarray with sparse disk.
     scan_size: Real space scan size (pixels)
     frame_size: detector size (pixels)
     center: the center of the disk in diffraction space
     how_sparse: Percent sparseness (0-1). Large number means fewer electrons per frame
     disk_size: The radius in pixels of the diffraction disk
-    
+    crop_to: The radius to crop to
     """ 
     
-#     scan_size = (100, 100)
-#     frame_size = (100,100)
-#     center = (30, 70)
-#     how_sparse = .8 # 0-1; larger is less electrons
-#     disk_size = 10 # disk radius in pixels
-
+    scan_size = (100, 100)
+    frame_size = (100,100)
+    center = (30, 70)
+    how_sparse = .8 # 0-1; larger is less electrons
+    disk_size = 10 # disk radius in pixels
+    
     YY, XX = np.mgrid[0:frame_size[0], 0:frame_size[1]]
     RR = np.sqrt((YY-center[1])**2 + (XX-center[0])**2)
 
@@ -162,6 +163,8 @@ def simulate_sparse_array(scan_size, frame_size, center, how_sparse, disk_size):
         'dtype': sparse.dtype,
         'sparse_slicing': True,
         'allow_full_expand': False,
+        
     }
-
-    return SparseArray(**kwargs)
+    sp = SparseArray(**kwargs)
+    sp._validate()
+    return sp

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -42,3 +42,19 @@ def test_radial_sum_sparse(sparse_array_10x10):
     rr = radial_sum_sparse(sparse_array_10x10, center=(5, 5))
 
     assert np.array_equal(rr[0, 0, :], [0, 6, 0, 0, 3])
+
+def test_com_sparse_parameters():
+    sp = simulate_sparse_array((100,100), (100,100), (30,70), (0.8), (10))
+    
+    # Test no inputs. This should be the full frame COM
+    com0 = com_sparse(sp)
+    assert int(com0[0,].mean()) == 30
+    
+    # Test crop_to input. Initial COM should be full frame COM
+    com1 = com_sparse(sp, crop_to=10)
+    assert int(com1[0,].mean()) == 30
+    
+    # Test crop_to and init_center input.
+    # No counts will be in the center so all positions will be np.nan
+    com2 = com_sparse(sp, crop_to=(10,10), init_center=(1,1))
+    assert np.isnan(com2[0,0,0])

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 
 from stempy.image import com_dense, com_sparse, radial_sum_sparse
@@ -43,16 +45,18 @@ def test_radial_sum_sparse(sparse_array_10x10):
 
     assert np.array_equal(rr[0, 0, :], [0, 6, 0, 0, 3])
 
-def test_com_sparse_parameters():
-    sp = simulate_sparse_array((100,100), (100,100), (30,70), (0.8), (10))
+def test_com_sparse_parameters(simulate_sparse_array):
+    
+    sp = simulate_sparse_array #((100,100), (100,100), (30,70), (0.8), (10))
+    breakpoint()
     
     # Test no inputs. This should be the full frame COM
     com0 = com_sparse(sp)
-    assert int(com0[0,].mean()) == 30
+    assert round(com0[0,].mean()) == 30
     
     # Test crop_to input. Initial COM should be full frame COM
     com1 = com_sparse(sp, crop_to=10)
-    assert int(com1[0,].mean()) == 30
+    assert round(com1[0,].mean()) == 30
     
     # Test crop_to and init_center input.
     # No counts will be in the center so all positions will be np.nan

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -48,14 +48,13 @@ def test_radial_sum_sparse(sparse_array_10x10):
 def test_com_sparse_parameters(simulate_sparse_array):
     
     sp = simulate_sparse_array #((100,100), (100,100), (30,70), (0.8), (10))
-    breakpoint()
     
     # Test no inputs. This should be the full frame COM
     com0 = com_sparse(sp)
     assert round(com0[0,].mean()) == 30
     
     # Test crop_to input. Initial COM should be full frame COM
-    com1 = com_sparse(sp, crop_to=10)
+    com1 = com_sparse(sp, crop_to=(10,10))
     assert round(com1[0,].mean()) == 30
     
     # Test crop_to and init_center input.


### PR DESCRIPTION
The logic in `com_sparse` was not correct when `init_center` was used and `crop_to` was not used. In this case the COM was returned as the `init_center`. This fixes that problem.

`com_sparse` will also set the COM to `nan` in cases where `crop_to` leads to no counts inside the cropped area. This matches the behavior for empty frames.

I also added a `pytest` fixture to return a simulated `SparseArray` with some variable parameters such as the size and position of the disk in diffraction space. I use this to test the new logic in `com_sparse`

@psavery How would I change `simulate_sparse_array` to have multiple frames per position? Im not sure the size of the `data` input to `SparseArray`'s `kwargs`.