### PR TITLE
Add analysis functions

### DIFF
--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -670,15 +670,12 @@ def virtual_darkfield(array, centers_x, centers_y, radii):
     :param radii: The radius of each aperture.
     :type radii: number or iterable
     
-    :param plot: If set to True then the apertures are plotted as circles using plot_virtual_darkfield
-    :rype plot: bool
-    
     :rtype: np.ndarray
     
     :example:
     >>> sp = stempy.io.load_electron_counts('file.h5')
-    >>> dp2 = stempy.image.virtual_darkfield(sp, (288, 260), (288, 160), (10, 10)) # 2 apertures
-    >>> dp1 = stempy.image.virtual_darkfield(sp, 260, 160, 10) # 1 aperture
+    >>> df2 = stempy.image.virtual_darkfield(sp, (288, 260), (288, 160), (10, 10)) # 2 apertures
+    >>> df1 = stempy.image.virtual_darkfield(sp, 260, 160, 10) # 1 aperture
     
     """
     
@@ -706,7 +703,7 @@ def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
     """Plot circles on the diffraction pattern corresponding to the position and size of virtual dark field apertures.
     This has the same center and radii inputs as stempy.image.virtual_darkfield so users can check their input is physically correct.
     
-    :param image: The diffraciton pattern to plot over
+    :param image: The diffraction pattern to plot over
     :type image: np.ndarray, 2D
     
     :param centers_x: The center of each round aperture as the row locations
@@ -715,7 +712,7 @@ def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
     :param centers_y: The center of each round aperture as the column locations
     :type centers_y: iterable
     
-    :param radii: The radius of each aperture. This has to be in the form (r0, )
+    :param radii: The radius of each aperture.
     :type radii: iterable
     
     :param axes: A matplotlib axes instance to use for the plotting. If None then a new plot is created.
@@ -725,7 +722,7 @@ def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
     
     :example:
     >>> sp = stempy.io.load_electron_counts('file.h5')
-    >>> stempy.image.plot_virtual_darkfield(sp.sum(axis=(0,1), 260, 160, 10) # 1 aperture
+    >>> stempy.image.plot_virtual_darkfield(sp.sum(axis=(0, 1), 260, 160, 10) # 1 aperture
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -701,3 +701,43 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
     rs_image = rs_image.reshape(sp.shape[0:2])
     
     return rs_image
+
+def plot_virtual_darkfield(array, centers_x, centers_y, radii, axes=None):
+    """Plot circles on the summed diffraction pattern corresponding to the position and size of virtual dark field apertures.
+    This has the same input as stempy.image.virtual_darkfield so users can check their input is physically correct.
+    
+    :param array: The SparseArray
+    :type array: SparseArray
+    
+    :param centers_x: The center of each round aperture as the row locations
+    :type centers_x: iterable
+    
+    :param centers_y: The center of each round aperture as the column locations
+    :type centers_y: iterable
+    
+    :param radii: The radius of each aperture. This has to be in the form (r0, )
+    :type radii: iterable
+    
+    :param axes: A matplotlib axes instance to use for the plotting. If None then a new plot is created.
+    :type axes: matplotlib.axes._subplots.AxesSubplot
+    
+    :rtype: matplotlib.axes._subplots.AxesSubplot
+    """
+    
+    from matplotlib.colors import LogNorm
+    
+    # Change to iterable if single value
+    if isinstance(centers_x, (int, float)):
+         centers_x = (centers_x,)
+    if isinstance(centers_y, (int, float)):
+         centers_y = (centers_y,)
+    if isinstance(radii, (int, float)):
+         radii = (radii,)
+    
+    if not axes:
+        fg, ax = plt.subplots(1, 1)
+    ax.imshow(array.sum(axis=(0, 1)), cmap='magma', norm=LogNorm())
+    for cc_0, cc_1, rr in zip(centers_x, centers_y, radii):
+        C = Circle((cc_0,cc_1),rr,fc='none',ec='c')
+        ax.add_patch(C)
+    return ax

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -693,8 +693,8 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
     rs_image = np.zeros((array.shape[0] * array.shape[1],), dtype=array.dtype)
     for ii, events in enumerate(array.data):
         for ev in events:
-            ev_rows = ev//array.frame_shape[0]
-            ev_cols = ev%array.frame_shape[1]
+            ev_rows = ev // array.frame_shape[0]
+            ev_cols = ev % array.frame_shape[1]
             for cc_0, cc_1, rr in zip(centers_x, centers_y, radii):
                 dist = np.sqrt((ev_rows - cc_1)**2 + (ev_cols - cc_0)**2)
                 rs_image[ii] += len(np.where(dist < rr)[0])

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -741,7 +741,7 @@ def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
     
     # Place a circle at each apertue location
     for cc_0, cc_1, rr in zip(centers_x, centers_y, radii):
-        C = Circle((cc_0,cc_1),rr,fc='none',ec='c')
+        C = Circle((cc_0, cc_1), rr, fc='none', ec='c')
         axes.add_patch(C)
     
     return axes

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -654,7 +654,7 @@ def _electron_counted_metadata_to_dict(metadata):
 
     return ret
 
-def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
+def virtual_darkfield(array, centers_x, centers_y, radii):
     """Calculate a virtual dark field image from a set of round virtual apertures in diffraction space.
     Each aperture is defined by a center and radius and the final image is the sum of all of them.
     
@@ -704,7 +704,7 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
 
 def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
     """Plot circles on the diffraction pattern corresponding to the position and size of virtual dark field apertures.
-    This has the same input as stempy.image.virtual_darkfield so users can check their input is physically correct.
+    This has the same center and radii inputs as stempy.image.virtual_darkfield so users can check their input is physically correct.
     
     :param image: The diffraciton pattern to plot over
     :type image: np.ndarray, 2D
@@ -722,6 +722,10 @@ def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
     :type axes: matplotlib.axes._subplots.AxesSubplot
     
     :rtype: matplotlib.axes._subplots.AxesSubplot
+    
+    :example:
+    >>> sp = stempy.io.load_electron_counts('file.h5')
+    >>> stempy.image.plot_virtual_darkfield(sp.sum(axis=(0,1), 260, 160, 10) # 1 aperture
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -698,7 +698,7 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
             for cc_0, cc_1, rr in zip(centers_x, centers_y, radii):
                 dist = np.sqrt((ev_rows - cc_1)**2 + (ev_cols - cc_0)**2)
                 rs_image[ii] += len(np.where(dist < rr)[0])
-    rs_image = rs_image.reshape(array.shape[0:2])
+    rs_image = rs_image.reshape(array.scan_shape)
     
     return rs_image
 

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -741,3 +741,23 @@ def plot_virtual_darkfield(array, centers_x, centers_y, radii, axes=None):
         C = Circle((cc_0,cc_1),rr,fc='none',ec='c')
         ax.add_patch(C)
     return ax
+
+def mask_real_space(array, mask):
+    """Calculate a diffraction pattern from an arbitrary set of positions defined in a mask in real space
+    
+    :param array: The sparse dataset
+    :type array: SparseArray
+    
+    :param mask: The mask to apply with 0 for probe positions to ignore and 1 for probe positions to include in the sum. Must have the same scan shape as array
+    :type mask: np.ndarray
+    
+    :rtype: np.ndarray
+    """
+    assert array.scan_shape[0] == mask.shape[0] and array.scan_shape[1] == mask.shape[1]
+    dp_mask = np.zeros(np.prod(array.frame_shape), array.dtype)
+    mr = np.ravel_multi_index(np.where(mask), array.scan_shape)
+    for events in array.data[mr, :]:
+        for ev in events:
+            dp_mask[ev] += 1
+    dp_mask = dp_mask.reshape(sp.frame_shape)
+    return dp_mask

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -677,8 +677,8 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
     
     :example:
     >>> sp = stempy.io.load_electron_counts('file.h5')
-    >>> dp2 = stempy.image.virtual_darkfile(sp,(288, 260), (288, 160), (10, 10)) # sum 2 apertures
-    >>> dp1 = stempy.image.virtual_darkfile(sp, 260, 160, 10) # 1 aperture
+    >>> dp2 = stempy.image.virtual_darkfield(sp, (288, 260), (288, 160), (10, 10)) # 2 apertures
+    >>> dp1 = stempy.image.virtual_darkfield(sp, 260, 160, 10) # 1 aperture
     
     """
     

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -723,7 +723,7 @@ def plot_virtual_darkfield(array, centers_x, centers_y, radii, axes=None):
     
     :rtype: matplotlib.axes._subplots.AxesSubplot
     """
-    
+    import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm
     
     # Change to iterable if single value

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -702,12 +702,12 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
     
     return rs_image
 
-def plot_virtual_darkfield(array, centers_x, centers_y, radii, axes=None):
-    """Plot circles on the summed diffraction pattern corresponding to the position and size of virtual dark field apertures.
+def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
+    """Plot circles on the diffraction pattern corresponding to the position and size of virtual dark field apertures.
     This has the same input as stempy.image.virtual_darkfield so users can check their input is physically correct.
     
-    :param array: The SparseArray
-    :type array: SparseArray
+    :param image: The diffraciton pattern to plot over
+    :type image: np.ndarray, 2D
     
     :param centers_x: The center of each round aperture as the row locations
     :type centers_x: iterable
@@ -735,12 +735,16 @@ def plot_virtual_darkfield(array, centers_x, centers_y, radii, axes=None):
          radii = (radii,)
     
     if not axes:
-        fg, ax = plt.subplots(1, 1)
-    ax.imshow(array.sum(axis=(0, 1)), cmap='magma', norm=LogNorm())
+        fg, axes = plt.subplots(1, 1)
+    
+    axes.imshow(image, cmap='magma', norm=LogNorm())
+    
+    # Place a circle at each apertue location
     for cc_0, cc_1, rr in zip(centers_x, centers_y, radii):
         C = Circle((cc_0,cc_1),rr,fc='none',ec='c')
-        ax.add_patch(C)
-    return ax
+        axes.add_patch(C)
+    
+    return axes
 
 def mask_real_space(array, mask):
     """Calculate a diffraction pattern from an arbitrary set of positions defined in a mask in real space

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -725,7 +725,8 @@ def plot_virtual_darkfield(image, centers_x, centers_y, radii, axes=None):
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm
-    
+    from matplotlib.patches import Circle
+
     # Change to iterable if single value
     if isinstance(centers_x, (int, float)):
          centers_x = (centers_x,)

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -698,7 +698,7 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
             for cc_0, cc_1, rr in zip(centers_x, centers_y, radii):
                 dist = np.sqrt((ev_rows - cc_1)**2 + (ev_cols - cc_0)**2)
                 rs_image[ii] += len(np.where(dist < rr)[0])
-    rs_image = rs_image.reshape(sp.shape[0:2])
+    rs_image = rs_image.reshape(array.shape[0:2])
     
     return rs_image
 
@@ -763,5 +763,5 @@ def mask_real_space(array, mask):
     for events in array.data[mr, :]:
         for ev in events:
             dp_mask[ev] += 1
-    dp_mask = dp_mask.reshape(sp.frame_shape)
+    dp_mask = dp_mask.reshape(array.frame_shape)
     return dp_mask

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -690,7 +690,7 @@ def virtual_darkfield(array, centers_x, centers_y, radii, plot=False):
     if isinstance(radii, (int, float)):
          radii = (radii,)
 
-    rs_image = np.zeros((array.shape[0] * sp.shape[1],), dtype=array.dtype)
+    rs_image = np.zeros((array.shape[0] * array.shape[1],), dtype=array.dtype)
     for ii, events in enumerate(array.data):
         for ev in events:
             ev_rows = ev//array.frame_shape[0]


### PR DESCRIPTION
This adds 3 functions for more detailed analysis. 

`virtual_darkfield` takes in centers and radii of circular apertures to place in diffraction space. A real space virtual darkfield image is returned where each probe position is the sum of the intensity in all apertures. See below for an example

`plot_virtual_darkfield` takes in the same arguments as `virtual_darkfield` and plots circles at each aperture position to check the output is physically meaningful.
```python
center_x = (288, 317) # col, row or X, Y from matplotlib plot
center_y = (363, 213) 
radii = (15, 15)

plot_virtual_darkfield(sp, center_x, center_y, radii)
```
<img width="320" alt="image" src="https://user-images.githubusercontent.com/15657108/202872663-1f4dcb49-d456-4d22-b136-e97feed504bf.png">


`mask_real_space` takes in a boolean array of positions matching the `scan_shape` of a `SparseArray` and outputs a summed diffraction pattern. The pattern is the sum of all positions with 1 or True in the mask. 
```python
dp_mask = mask_real_space(sp, mask)
```

<img width="271" alt="image" src="https://user-images.githubusercontent.com/15657108/202872797-5fd8f425-de11-4890-a703-a7290bfd0ff3.png">
