### PR TITLE
Add method for reading frames at a scan position

### DIFF
--- a/python/io.cpp
+++ b/python/io.cpp
@@ -126,5 +126,10 @@ PYBIND11_MODULE(_io, m)
     .def(py::init<const std::string&, int>(), py::arg("path"),
          py::arg("threads") = 0)
     .def(py::init<const std::vector<std::string>&, int>(), py::arg("files"),
-         py::arg("threads") = 0);
+         py::arg("threads") = 0)
+    .def("_load_frames", &SectorStreamMultiPassThreadedReader::loadFrames)
+    .def("_num_frames_per_scan",
+         &SectorStreamMultiPassThreadedReader::numFramesPerScan)
+    .def("_scan_dimensions",
+         &SectorStreamMultiPassThreadedReader::scanDimensions);
 }

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -521,13 +521,13 @@ public:
   // read yet (so that it may find the scan position that is requested).
   // It will then read the specified frames at the frame position.
   template <typename Functor>
-  void readFrames(Functor& func, Dimensions2D scanPosition,
+  void readFrames(Functor& func, uint32_t imageNumber,
                   const std::vector<uint32_t>& frameIndices);
 
   // Read the frames and return the associated blocks.
   // This is the same as the readFrames() function, but its functor just
   // saves a vector of the blocks.
-  std::vector<Block> loadFrames(Dimensions2D scanPosition,
+  std::vector<Block> loadFrames(uint32_t imageNumber,
                                 const std::vector<uint32_t>& frameIndices);
 
   Dimensions2D scanDimensions()
@@ -757,25 +757,17 @@ inline void SectorStreamMultiPassThreadedReader::initializeScanMap()
 
 template <typename Functor>
 void SectorStreamMultiPassThreadedReader::readFrames(
-  Functor& func, Dimensions2D scanPosition,
+  Functor& func, uint32_t imageNumber,
   const std::vector<uint32_t>& frameIndices)
 {
   // This will only initialize the scan map if it hasn't already been
   // initialized.
   initializeScanMap();
 
-  // Unravel the scan position to an image number
-  // NOTE: we need to swap dimensions when unraveling this scan position,
-  // because the position is specified that way.
-  auto imageNumber =
-    scanPosition.first * m_scanDimensions.first + scanPosition.second;
-
   if (imageNumber >= m_scanMap.size()) {
     std::ostringstream msg;
     msg << "Image number " << imageNumber << " is out of bounds! "
-        << "Scan position provided was (" << scanPosition.first << ", "
-        << scanPosition.second << "), and scan shape is ("
-        << m_scanDimensions.second << ", " << m_scanDimensions.first << ").";
+        << "There are " << m_scanMap.size() << " scans.\n";
     throw std::invalid_argument(msg.str());
   }
 
@@ -807,14 +799,14 @@ void SectorStreamMultiPassThreadedReader::readFrames(
 }
 
 inline std::vector<Block> SectorStreamMultiPassThreadedReader::loadFrames(
-  Dimensions2D scanPosition, const std::vector<uint32_t>& frameIndices)
+  uint32_t imageNumber, const std::vector<uint32_t>& frameIndices)
 {
   std::vector<Block> ret;
 
   // For the functor, we will just append the blocks and return them.
   auto functor = [&ret](Block& b) { ret.push_back(b); };
 
-  readFrames(functor, scanPosition, frameIndices);
+  readFrames(functor, imageNumber, frameIndices);
 
   return ret;
 }


### PR DESCRIPTION
This refactors the `SectorStreamMultiPassThreadedReader` class a little bit and adds methods for reading specific frames from the data.

Reading the frames requires first reading all of the headers of the data (which can take some time, since we have to parse the data files). But once the headers have been read once, they are cached so that they do not need to be read again.

Here is some example code:

```python
import glob

import stempy.io as stio

backend = 'multi-pass'
files = glob.glob('*.data')

reader = stio.reader(files, stio.FileVersion.VERSION5, backend=backend)

blocks = reader.read_frames((5, 30), [1, 2, 3])

for block in blocks:
    array = block.data  # this is the numpy array for the block
```

The `frames_slice` argument is used to slice directly into a `np.arange(num_frames)` array, and the result is used to determine which frames, and in what order, get returned.

A couple of additional methods were added for convenience:

1. `reader.scan_shape` will return the scan shape (if a header hasn't been read yet, it will automatically read one header to determine this)
2. `reader.num_frames_per_scan` will return the number of frames per scan. This must read all of the headers, and can be time consuming if that hasn't been done yet (but reading all of the headers will only happen once per reader object).

Fixes: #279