### PR TITLE
avoid type conversion to float on h5 import

### DIFF
--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -1,8 +1,8 @@
-from collections.abc import Sequence
 import copy
-from functools import wraps
 import inspect
 import sys
+from collections.abc import Sequence
+from functools import wraps
 
 import numpy as np
 
@@ -202,8 +202,10 @@ class SparseArray:
         scan_shape = scan_shape[::-1]
 
         if version >= 3:
+            # Convert to int to avoid integer division that results in 
+            # a float
+            frames_per_scan = len(data) // int(np.prod(scan_shape))
             # Need to reshape the data, as it was flattened before saving
-            frames_per_scan = len(data) // np.prod(scan_shape)
             data = data.reshape((np.prod(scan_shape), frames_per_scan))
 
         # We may need to convert the version of the data

--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -1,8 +1,8 @@
+from collections.abc import Sequence
 import copy
+from functools import wraps
 import inspect
 import sys
-from collections.abc import Sequence
-from functools import wraps
 
 import numpy as np
 

--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -204,7 +204,7 @@ class SparseArray:
         if version >= 3:
             # Convert to int to avoid integer division that results in 
             # a float
-            frames_per_scan = len(data) // int(np.prod(scan_shape))
+            frames_per_scan = len(data) // np.prod(scan_shape, dtype=int)
             # Need to reshape the data, as it was flattened before saving
             data = data.reshape((np.prod(scan_shape), frames_per_scan))
 


### PR DESCRIPTION
This is a small PR that avoids type conversion behavior to float on integer division.

@ercius and I (mostly @ercius) figured out that this line:

```python
data = data.reshape((np.prod(scan_shape), frames_per_scan))
```

Fails with:

```python
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```

When the type of the `scan_shape` list is an unsigned int, `np.prod(scan_shape)`, and integer division results in a float64:

```python 
frames_per_scan = len(data) // np.prod(scan_shape) # (python int) // np.uint 
print(frames_per_scan.dtype)
# float64
```
This change ensures that this conversion doesn't happen.