### PR TITLE
Use BigMPI to send events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ if (stempy_ENABLE_MPI)
   include_directories(
     SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/Empirical/include
   )
+
+  find_package(BigMPI REQUIRED)
+  list(APPEND _libs bigmpi::bigmpi)
 endif()
 set(USE_MPI ${MPI_FOUND})
 

--- a/cmake/FindBigMPI.cmake
+++ b/cmake/FindBigMPI.cmake
@@ -1,0 +1,26 @@
+# Defines:
+#
+#  BIGMPI_FOUND        - system has
+#  BIGMPI_INCLUDE_DIRS - the BigMPI include directories
+#  BIGMPI_LIBRARY      - the BigMPI library
+#
+find_path(BIGMPI_INCLUDE_DIR bigmpi.h)
+find_library(BIGMPI_LIBRARY NAMES bigmpi)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(BigMPI DEFAULT_MSG BIGMPI_INCLUDE_DIR
+                                  BIGMPI_LIBRARY)
+
+mark_as_advanced(BIGMPI_INCLUDE_DIR BIGMPI_LIBRARY)
+
+if(BIGMPI_FOUND)
+  set(BIGMPI_INCLUDE_DIRS "${BIGMPI_INCLUDE_DIR}")
+
+  if(NOT TARGET bigmpi::bigmpi)
+    add_library(bigmpi::bigmpi SHARED IMPORTED GLOBAL)
+    set_target_properties(bigmpi::bigmpi PROPERTIES
+      IMPORTED_LOCATION "${BIGMPI_LIBRARY}"
+      IMPORTED_IMPLIB "${BIGMPI_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${BIGMPI_INCLUDE_DIR}")
+  endif()
+endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,14 @@ RUN apt-get update && \
   libssl1.0-dev \
   git \
   autoconf \
+  libtool \
   automake \
   gcc \
   g++ \
   make \
   gfortran \
+  libopenblas-dev \
+  liblapack-dev \
   wget \
   zlib1g-dev \
   libffi-dev \
@@ -52,6 +55,11 @@ RUN cd /build && wget https://bitbucket.org/mpi4py/mpi4py/downloads/mpi4py-3.0.1
 
 RUN cd /build/mpi4py-3.0.1 && python3 setup.py build && python3 setup.py install
 
+# Build BigMPI
+RUN cd /build && wget https://github.com/jeffhammond/BigMPI/archive/refs/heads/master.tar.gz && \
+  tar zxvf master.tar.gz  && cd /build/BigMPI-master && \
+  ./autogen.sh && ./configure && make -j4 && make install && make clean && rm /build/master.tar.gz
+
 # Build VTK-m
 RUN cd /source && \
   wget https://gitlab.kitware.com/vtk/vtk-m/-/archive/v1.5.0/vtk-m-v1.5.0.tar.gz && \
@@ -77,6 +85,8 @@ RUN mkdir -p /build/stempy && \
   -Dstempy_ENABLE_VTKm:BOOL=ON \
   -DVTKm_DIR:PATH=/build/vtk-m/lib/cmake/vtkm-1.5 \
   -Dstempy_ENABLE_MPI:BOOL=${MPI} \
+  -DBIGMPI_INCLUDE_DIR:PATH=/usr/local/include \
+  -DBIGMPI_LIBRARY:PATH=/usr/local/lib/libbigmpi.a \
   /source/stempy . && \
   make -j4
 


### PR DESCRIPTION
With the new detector and multiple frames per scan position we are starting to get more events than can be sent in a regular MPI message. This adds BigMPI to increase the size of the messages we can sent to get around this restriction.