### PR TITLE
acquire gil before creating numpy array

### DIFF
--- a/python/image.cpp
+++ b/python/image.cpp
@@ -33,6 +33,7 @@ struct ElectronCountedDataPyArray
 
   ElectronCountedDataPyArray(ElectronCountedData&& other)
   {
+    py::gil_scoped_acquire acquire;
     data.resize(other.data.size());
     for (size_t i = 0; i < other.data.size(); ++i) {
       data[i].reserve(other.data[i].size());


### PR DESCRIPTION
Fixes #275 

Tested with python versions 3.7 - 3.10, counting works fine on Perlmutter.