### PR TITLE
Big MPI fix

### DIFF
--- a/stempy/electron_mpi.cpp
+++ b/stempy/electron_mpi.cpp
@@ -34,21 +34,22 @@ void serializeBlocks(std::vector<Block>& blocks, std::ostream* stream)
   archive(blocks);
 }
 
-void receivePartialMap(Events& events, std::vector<char>& recvBuffer)
+void receivePartialMap(Events& events, std::vector<char>& recvBuffer,
+                       int sourceRank)
 {
   MPI_Status status;
 
-  // First get the message size
+  // First get msg size using the source rank as the tag
   size_t msgSize;
-  MPI_Recv(&msgSize, 1, MPI_UINT64_T, MPI_ANY_SOURCE, 0, MPI_COMM_WORLD,
+  MPI_Recv(&msgSize, 1, MPI_UINT64_T, sourceRank, sourceRank, MPI_COMM_WORLD,
            MPI_STATUS_IGNORE);
 
   // Resize our buffer
   recvBuffer.resize(msgSize);
 
   // Now receive the data using BigMPI
-  MPIX_Recv_x(recvBuffer.data(), recvBuffer.size(), MPI_BYTE, MPI_ANY_SOURCE, 0,
-              MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+  MPIX_Recv_x(recvBuffer.data(), recvBuffer.size(), MPI_BYTE, sourceRank,
+              sourceRank, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
   StreamView view(recvBuffer.data(), recvBuffer.size());
   std::istream stream(&view);
@@ -67,7 +68,7 @@ void receivePartialMap(Events& events, std::vector<char>& recvBuffer)
   }
 }
 
-void sendPartialMap(Events& events)
+void sendPartialMap(Events& events, int rank)
 {
   // Create a partial map of electron events
   SparseEventMap partialEventMap;
@@ -87,11 +88,12 @@ void sendPartialMap(Events& events)
 
   // First send the size
   auto size = eventsContiguousStream.GetSize();
-  MPI_Send(&size, 1, MPI_UINT64_T, 0, 0, MPI_COMM_WORLD);
+  MPI_Send(&size, 1, MPI_UINT64_T, 0, rank, MPI_COMM_WORLD);
 
   // Now send the data using BigMPI
   MPIX_Send_x(eventsContiguousStream.GetData(),
-              eventsContiguousStream.GetSize(), MPI_BYTE, 0, 0, MPI_COMM_WORLD);
+              eventsContiguousStream.GetSize(), MPI_BYTE, 0, rank,
+              MPI_COMM_WORLD);
 }
 
 void gatherEvents(int worldSize, int rank, Events& events)
@@ -106,13 +108,13 @@ void gatherEvents(int worldSize, int rank, Events& events)
     // We pass this buffer in as we might be able to reduce the reallocations.
     std::vector<char> recvBuffer;
     // One receive for each other rank
-    for (auto i = 0; i < worldSize - 1; i++) {
-      receivePartialMap(events, recvBuffer);
+    for (int sourceRank = 1; sourceRank < worldSize; sourceRank++) {
+      receivePartialMap(events, recvBuffer, sourceRank);
     }
   }
   // Send partial maps to rank 0
   else {
-    sendPartialMap(events);
+    sendPartialMap(events, rank);
   }
 }
 

--- a/stempy/electron_mpi.cpp
+++ b/stempy/electron_mpi.cpp
@@ -39,9 +39,9 @@ void receivePartialMap(Events& events, std::vector<char>& recvBuffer,
 {
   MPI_Status status;
 
-  // First get msg size using the source rank as the tag
+  // First get msg size using the source rank
   size_t msgSize;
-  MPI_Recv(&msgSize, 1, MPI_UINT64_T, sourceRank, sourceRank, MPI_COMM_WORLD,
+  MPI_Recv(&msgSize, 1, MPI_UINT64_T, sourceRank, 0, MPI_COMM_WORLD,
            MPI_STATUS_IGNORE);
 
   // Resize our buffer
@@ -49,7 +49,7 @@ void receivePartialMap(Events& events, std::vector<char>& recvBuffer,
 
   // Now receive the data using BigMPI
   MPIX_Recv_x(recvBuffer.data(), recvBuffer.size(), MPI_BYTE, sourceRank,
-              sourceRank, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+              0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
   StreamView view(recvBuffer.data(), recvBuffer.size());
   std::istream stream(&view);
@@ -68,7 +68,7 @@ void receivePartialMap(Events& events, std::vector<char>& recvBuffer,
   }
 }
 
-void sendPartialMap(Events& events, int rank)
+void sendPartialMap(Events& events)
 {
   // Create a partial map of electron events
   SparseEventMap partialEventMap;
@@ -88,12 +88,11 @@ void sendPartialMap(Events& events, int rank)
 
   // First send the size
   auto size = eventsContiguousStream.GetSize();
-  MPI_Send(&size, 1, MPI_UINT64_T, 0, rank, MPI_COMM_WORLD);
+  MPI_Send(&size, 1, MPI_UINT64_T, 0, 0, MPI_COMM_WORLD);
 
   // Now send the data using BigMPI
   MPIX_Send_x(eventsContiguousStream.GetData(),
-              eventsContiguousStream.GetSize(), MPI_BYTE, 0, rank,
-              MPI_COMM_WORLD);
+              eventsContiguousStream.GetSize(), MPI_BYTE, 0, 0, MPI_COMM_WORLD);
 }
 
 void gatherEvents(int worldSize, int rank, Events& events)
@@ -114,7 +113,7 @@ void gatherEvents(int worldSize, int rank, Events& events)
   }
   // Send partial maps to rank 0
   else {
-    sendPartialMap(events, rank);
+    sendPartialMap(events);
   }
 }
 


### PR DESCRIPTION
See #292 for details on this fix. 

I think the sends/receives were mixing up the message size message and the data messages, because of MPI_ANY_SOURCE.

I tested this and it works.