### PR TITLE
Build wheels for Python 3.11 also

### DIFF
--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/pypa/manylinux2010_x86_64
+ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64
 FROM ${BASE_IMAGE}
 
 RUN yum install -y \

--- a/.github/scripts/docker/build_and_push.sh
+++ b/.github/scripts/docker/build_and_push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-image_base=quay.io/pypa/manylinux2010_x86_64
+image_base=quay.io/pypa/manylinux2014_x86_64
 tag=openchemistry/stempy_wheel_builder
 
 docker build . -t $tag --build-arg BASE_IMAGE=$image_base

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,8 +9,8 @@ on:
   pull_request:
 
 env:
-  # Only support 64-bit CPython > 3.6, < 3.11
-  CIBW_SKIP: "cp36-* cp311-* pp* *-manylinux_i686 *-musllinux_* *-win32"
+  # Only support 64-bit CPython > 3.6
+  CIBW_SKIP: "cp36-* pp* *-manylinux_i686 *-musllinux_* *-win32"
 
   # This has some of the software we need pre-installed on it
   CIBW_MANYLINUX_X86_64_IMAGE: openchemistry/stempy_wheel_builder


### PR DESCRIPTION
I believe Python 3.11 wheels were being skipped because, at the time, several dependencies did not have Python 3.11 support.

But our dependencies should have Python 3.11 support now. So let's add back in Python 3.11.

Fixes: #294