### PR TITLE
Remove flyback

### DIFF
--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -259,16 +259,17 @@ def save_electron_counts(path, array):
     """
     array.write_to_hdf5(path)
 
-def load_electron_counts(path):
+def load_electron_counts(path, keep_flyback=True):
     """Load electron counted data from an HDF5 file.
 
     :param path: path to the HDF5 file.
     :type path: str
-
+    :param keep_flyback: option to crop the flyback column during loading
+    :type keep_flyback: bool
     :return: a SparseArray containing the electron counted data
     :rtype: SparseArray
     """
-    return SparseArray.from_hdf5(path)
+    return SparseArray.from_hdf5(path, keep_flyback=keep_flyback)
 
 def save_stem_images(outputFile, images, names):
     """Save STEM images to an HDF5 file.

--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -197,24 +197,32 @@ class SparseArray:
                 data = frames[()] # load the full data set
                 scan_positions = scan_positions_group[()]
             else:
+                print(scan_shape)
                 # Generate the original scan indices from the scan_shape
                 orig_indices = np.ravel_multi_index([ii.ravel() for ii in np.indices(scan_shape)],scan_shape)
+                print(orig_indices.shape)
+                print(orig_indices)
                 # Remove the indices of the last column 
-                crop_indices = np.delete(orig_indices, orig_indices[::scan_shape[1]])
+                crop_indices = np.delete(orig_indices, orig_indices[scan_shape[0]-1::scan_shape[0]])
+                print(crop_indices.shape)
+                print(crop_indices)
                 # Load only the data needed
                 data = frames[crop_indices]
+                print(data.shape)
                 # Reduce the column shape by 1
-                scan_shape[1] = scan_shape[1] - 1
+                scan_shape[0] = scan_shape[0] - 1
                 # Create the proper scan_positions without the flyback column
                 scan_positions = np.ravel_multi_index([ii.ravel() for ii in np.indices(scan_shape)],scan_shape)
-            
+                
             # Load any metadata
             metadata = {}
             if 'metadata' in f:
                 load_h5_to_dict(f['metadata'], metadata)
 
         scan_shape = scan_shape[::-1]
-
+        
+        print(scan_shape)
+        
         if version >= 3:
             # Convert to int to avoid integer division that results in 
             # a float

--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -197,18 +197,12 @@ class SparseArray:
                 data = frames[()] # load the full data set
                 scan_positions = scan_positions_group[()]
             else:
-                print(scan_shape)
                 # Generate the original scan indices from the scan_shape
                 orig_indices = np.ravel_multi_index([ii.ravel() for ii in np.indices(scan_shape)],scan_shape)
-                print(orig_indices.shape)
-                print(orig_indices)
                 # Remove the indices of the last column 
                 crop_indices = np.delete(orig_indices, orig_indices[scan_shape[0]-1::scan_shape[0]])
-                print(crop_indices.shape)
-                print(crop_indices)
                 # Load only the data needed
                 data = frames[crop_indices]
-                print(data.shape)
                 # Reduce the column shape by 1
                 scan_shape[0] = scan_shape[0] - 1
                 # Create the proper scan_positions without the flyback column
@@ -220,8 +214,6 @@ class SparseArray:
                 load_h5_to_dict(f['metadata'], metadata)
 
         scan_shape = scan_shape[::-1]
-        
-        print(scan_shape)
         
         if version >= 3:
             # Convert to int to avoid integer division that results in 

--- a/python/stempy/io/sparse_array.py
+++ b/python/stempy/io/sparse_array.py
@@ -194,13 +194,19 @@ class SparseArray:
             frame_shape = [frames.attrs[x] for x in ['Nx', 'Ny']]
             
             if keep_flyback:
-                data = frames[()]
+                data = frames[()] # load the full data set
+                scan_positions = scan_positions_group[()]
             else:
+                # Generate the original scan indices from the scan_shape
                 orig_indices = np.ravel_multi_index([ii.ravel() for ii in np.indices(scan_shape)],scan_shape)
+                # Remove the indices of the last column 
                 crop_indices = np.delete(orig_indices, orig_indices[::scan_shape[1]])
+                # Load only the data needed
                 data = frames[crop_indices]
+                # Reduce the column shape by 1
                 scan_shape[1] = scan_shape[1] - 1
-
+                # Create the proper scan_positions without the flyback column
+                scan_positions = np.ravel_multi_index([ii.ravel() for ii in np.indices(scan_shape)],scan_shape)
             
             # Load any metadata
             metadata = {}

--- a/tests/test_sparse_array.py
+++ b/tests/test_sparse_array.py
@@ -710,12 +710,11 @@ def test_advanced_indexing(sparse_array_small, full_array_small):
     assert np.array_equal(m_array[[False, True], 0][0], position_one)
 
 
-def test_keep_flyback(sparse_array_small):
-    pass
-    #flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
-    #assert flyback.scan_shape[1] == 50
-    #no_flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
-    #assert flyback.scan_shape[1] == 49
+def test_keep_flyback(electron_data_small):
+    flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
+    assert flyback.scan_shape[1] == 50
+    no_flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=False)
+    assert no_flyback.scan_shape[1] == 49
     
 # Test binning until this number
 TEST_BINNING_UNTIL = 33

--- a/tests/test_sparse_array.py
+++ b/tests/test_sparse_array.py
@@ -710,6 +710,12 @@ def test_advanced_indexing(sparse_array_small, full_array_small):
     assert np.array_equal(m_array[[False, True], 0][0], position_one)
 
 
+def test_keep_flyback(sparse_array_small):
+    flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
+    assert flyback.scan_shape[1] == 50
+    no_flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
+    assert flyback.scan_shape[1] == 49
+    
 # Test binning until this number
 TEST_BINNING_UNTIL = 33
 

--- a/tests/test_sparse_array.py
+++ b/tests/test_sparse_array.py
@@ -711,10 +711,11 @@ def test_advanced_indexing(sparse_array_small, full_array_small):
 
 
 def test_keep_flyback(sparse_array_small):
-    flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
-    assert flyback.scan_shape[1] == 50
-    no_flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
-    assert flyback.scan_shape[1] == 49
+    pass
+    #flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
+    #assert flyback.scan_shape[1] == 50
+    #no_flyback = SparseArray.from_hdf5(electron_data_small, keep_flyback=True)
+    #assert flyback.scan_shape[1] == 49
     
 # Test binning until this number
 TEST_BINNING_UNTIL = 33


### PR DESCRIPTION
Update `from_hdf5` to allow the user to crop the flyback column during load. For large data sets this can reduce the time needed in processing later significantly. The keyword is set to `True` to be compatible with older code. 

Need to fully test once the CI builds are available. Dont merge yet. Will update as needed.