### PR TITLE
Allow reader to be instantiated without files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.19)
 project(stempy)
 
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(stempy_CMAKE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${stempy_CMAKE_DIR})
 
 include(InstallLocation)
 include(CMakeDependentOption)
+include(CMakePackageConfigHelpers)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -19,10 +21,6 @@ endif()
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
-)
-
-include_directories(SYSTEM
-  ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/ThreadPool
 )
 
 find_package(Threads)
@@ -125,6 +123,12 @@ if (stempy_ENABLE_HDF5 AND NOT ("${HDF5_VERSION}" VERSION_LESS 1.12.0))
   target_compile_options(stem PRIVATE "-DH5Ovisit_vers=1")
 endif()
 
+target_include_directories(stem
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/ThreadPool>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR};${CMAKE_INSTALL_INCLUDEDIR}/thirdparty/ThreadPool>"
+)
+
 set_property(TARGET stem PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(stem
@@ -155,9 +159,42 @@ if (NOT SKBUILD)
 endif()
 install(TARGETS stem LIBRARY DESTINATION "${_python_module_install_dir}")
 
+install(TARGETS stem
+        EXPORT stempyTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES stempy/reader.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
+install(FILES stempy/image.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
+install(FILES stempy/electron.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
+install(FILES thirdparty/ThreadPool/ThreadPool.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/thirdparty/ThreadPool)
+
 set(VTKm ${VTKm_FOUND})
 set(ENABLE_HDF5 ${HDF5_FOUND})
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.in"
+configure_file("${stempy_CMAKE_DIR}/config.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/config.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
+install(EXPORT stempyTargets
+      FILE stempyTargets.cmake
+      NAMESPACE stempy::
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/stempy
+)
+
+# Also run export(...) so we can use from a build directory as well
+export(TARGETS stem NAMESPACE stempy:: FILE stempyTargets.cmake)
+
+configure_package_config_file(${stempy_CMAKE_DIR}/stempyConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/stempyConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/stempy
+)
+
+install(FILES
+          "${CMAKE_CURRENT_BINARY_DIR}/stempyConfig.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/stempy
+)
 
 add_subdirectory(python)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ install(TARGETS stem
 
 install(FILES stempy/reader.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
 install(FILES stempy/image.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
+install(FILES stempy/mask.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
 install(FILES stempy/electron.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stempy)
 install(FILES thirdparty/ThreadPool/ThreadPool.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/thirdparty/ThreadPool)
 

--- a/cmake/stempyConfig.cmake.in
+++ b/cmake/stempyConfig.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/stempyTargets.cmake")
+
+check_required_components(stempy)
+
+find_package(Python3 REQUIRED COMPONENTS Development)
+
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/stempy")
+include_directories("${CMAKE_CURRENT_LIST_DIR}")

--- a/stempy/electron_mpi.cpp
+++ b/stempy/electron_mpi.cpp
@@ -11,6 +11,8 @@
 #include <emp/io/ContiguousStream.hpp>
 #include <mpi.h>
 #include <vector>
+#include <climits>
+#include <numeric>
 
 namespace stempy {
 

--- a/stempy/image.h
+++ b/stempy/image.h
@@ -2,16 +2,9 @@
 #define stempyimages_h
 
 #include "mask.h"
-#include "reader.h"
 
 #include <memory>
 #include <vector>
-
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
-namespace py = pybind11;
 
 namespace stempy {
 

--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -315,6 +315,21 @@ SectorStreamReader::SectorStreamReader(const vector<string>& files,
   m_streamsIterator = m_streams.begin();
 }
 
+SectorStreamReader::SectorStreamReader(uint8_t version) : m_version(version)
+{
+  // Validate version
+  switch (m_version) {
+    case 4:
+    case 5:
+      break;
+    default:
+      std::ostringstream ss;
+      ss << "Unsupported version: ";
+      ss << m_version;
+      throw invalid_argument(ss.str());
+  }
+}
+
 SectorStreamReader::~SectorStreamReader()
 {
   m_streams.clear();
@@ -777,6 +792,13 @@ SectorStreamThreadedReader::SectorStreamThreadedReader(const std::string& path,
 SectorStreamThreadedReader::SectorStreamThreadedReader(
   const std::vector<std::string>& files, uint8_t version, int threads)
   : SectorStreamReader(files, version), m_threads(threads)
+{
+  initNumberOfThreads();
+}
+
+SectorStreamThreadedReader::SectorStreamThreadedReader(uint8_t version,
+                                                       int threads)
+  : SectorStreamReader(version), m_threads(threads)
 {
   initNumberOfThreads();
 }

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -197,6 +197,7 @@ public:
   SectorStreamReader(const std::string& path, uint8_t version = 5);
   SectorStreamReader(const std::vector<std::string>& files,
                      uint8_t version = 5);
+  SectorStreamReader(uint8_t version = 5);
   ~SectorStreamReader();
 
   Block read();
@@ -334,6 +335,7 @@ public:
                              int threads = 0);
   SectorStreamThreadedReader(const std::vector<std::string>& files,
                              uint8_t version = 5, int threads = 0);
+  SectorStreamThreadedReader(uint8_t version = 5, int threads = 0);
 
   template <typename Functor>
   std::future<void> readAll(Functor& f);
@@ -348,7 +350,7 @@ protected:
   // The futures associated with the worker threads
   std::vector<std::future<void>> m_futures;
 
-private:
+protected:
   // Protect access to frame cache
   std::mutex m_cacheMutex;
 


### PR DESCRIPTION
This allows for the SectorStreamThreadedReader to be created without the vector of files argument. It also allows subclasses to access its mutexes (private --> protected). 

`StreamReader` superclass instantiation will throw an error if no files are provided.