### PR TITLE
Allow reader to be instantiated without files

### DIFF
--- a/stempy/reader.cpp
+++ b/stempy/reader.cpp
@@ -315,6 +315,21 @@ SectorStreamReader::SectorStreamReader(const vector<string>& files,
   m_streamsIterator = m_streams.begin();
 }
 
+SectorStreamReader::SectorStreamReader(uint8_t version) : m_version(version)
+{
+  // Validate version
+  switch (m_version) {
+    case 4:
+    case 5:
+      break;
+    default:
+      std::ostringstream ss;
+      ss << "Unsupported version: ";
+      ss << m_version;
+      throw invalid_argument(ss.str());
+  }
+}
+
 SectorStreamReader::~SectorStreamReader()
 {
   m_streams.clear();
@@ -777,6 +792,13 @@ SectorStreamThreadedReader::SectorStreamThreadedReader(const std::string& path,
 SectorStreamThreadedReader::SectorStreamThreadedReader(
   const std::vector<std::string>& files, uint8_t version, int threads)
   : SectorStreamReader(files, version), m_threads(threads)
+{
+  initNumberOfThreads();
+}
+
+SectorStreamThreadedReader::SectorStreamThreadedReader(uint8_t version,
+                                                       int threads)
+  : SectorStreamReader(version), m_threads(threads)
 {
   initNumberOfThreads();
 }

--- a/stempy/reader.h
+++ b/stempy/reader.h
@@ -197,6 +197,7 @@ public:
   SectorStreamReader(const std::string& path, uint8_t version = 5);
   SectorStreamReader(const std::vector<std::string>& files,
                      uint8_t version = 5);
+  SectorStreamReader(uint8_t version = 5);
   ~SectorStreamReader();
 
   Block read();
@@ -334,6 +335,7 @@ public:
                              int threads = 0);
   SectorStreamThreadedReader(const std::vector<std::string>& files,
                              uint8_t version = 5, int threads = 0);
+  SectorStreamThreadedReader(uint8_t version = 5, int threads = 0);
 
   template <typename Functor>
   std::future<void> readAll(Functor& f);
@@ -348,7 +350,7 @@ protected:
   // The futures associated with the worker threads
   std::vector<std::future<void>> m_futures;
 
-private:
+protected:
   // Protect access to frame cache
   std::mutex m_cacheMutex;
 


### PR DESCRIPTION
This allows for the `SectorStreamThreadedReader` to be created without the vector of files argument. It also allows subclasses to access its mutexes (private --> protected).

`StreamReader` superclass instantiation will throw an error if no files are provided.