### PR TITLE
add devcontainer for vscode developement

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// devcontainer.json for MPI off
+{
+    "name": "MPI Off",
+    "build": {
+      "context": "..",
+      "dockerfile": "../docker/Dockerfile.stempy",
+      "args": {
+        "PYTHON_VERSION": "3.9",
+        "DEV": "-dev",
+        "MPI": "OFF",
+        "RELEASE_OR_DEBUG": "Debug",
+        "IPYKERNEL": "",
+        "BASE_IMAGE": "openchemistry/stempy:py39-base"
+      }
+    },
+    "features": {
+      "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+            "ms-azuretools.vscode-docker",
+            "ms-python.black-formatter",
+            "ms-python.debugpy",
+            "ms-python.isort",
+            "ms-python.python",
+            "psioniq.psi-header",
+            "ms-vscode.cpptools",
+            "GitHub.copilot",
+            "ms-vscode.cmake-tools"
+        ]
+      }
+    }
+  }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,28 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 19,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "debug",
+            "description": "Debug build with VTKm disabled and MPI disabled",
+            "binaryDir": "${sourceDir}/output/debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "stempy_ENABLE_VTKm": "OFF",
+                "stempy_ENABLE_MPI": "OFF"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "debug",
+            "description": "Build using the debug configuration",
+            "jobs": 4
+        }
+    ]
+}


### PR DESCRIPTION
Adds devcontainer for local dev on vscode.

You have to build/pull base image first in order to use it.