### PR TITLE
Fix frames per block

### DIFF
--- a/python/pyreader.cpp
+++ b/python/pyreader.cpp
@@ -49,7 +49,7 @@ PyBlock PyReader::read()
     imageNumberForBlock.push_back(m_imageNumbers[i]);
   }
 
-  b.header = Header(frameDimensions, m_imageNumInBlock, m_scanDimensions,
+  b.header = Header(frameDimensions, imageNumberForBlock.size(), m_scanDimensions,
                     imageNumberForBlock);
   b.header.version = 3;
 


### PR DESCRIPTION
For the last block in a scan the number of frames may not be exactly the specified number of frames per block. So use the size of the image numbers vector.