### PR TITLE
Fix docker CI builds

### DIFF
--- a/.github/actions/docker_setup/action.yml
+++ b/.github/actions/docker_setup/action.yml
@@ -29,4 +29,4 @@ runs:
         username: ${{ inputs.DOCKERHUB_USERNAME }}
         password: ${{ inputs.DOCKERHUB_TOKEN }}
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3

--- a/docker/Dockerfile.stempy
+++ b/docker/Dockerfile.stempy
@@ -25,6 +25,8 @@ RUN mkdir -p /build/stempy                                                      
     cp -r -L /build/stempy/lib/stempy \
     /usr/local/lib/python${PYTHON_VERSION}/site-packages
 
+ENV MPI4PY_BUILD_BACKEND="scikit-build-core"
+
 RUN if [ "${IPYKERNEL}" = "ipykernel" ]; then \
     pip install --no-cache-dir -r /source/stempy/docker/requirements-ipykernel.txt; \
     elif [ "${MPI}" = "ON" ]; then \

--- a/docker/Dockerfile.stempy
+++ b/docker/Dockerfile.stempy
@@ -26,11 +26,11 @@ RUN mkdir -p /build/stempy                                                      
     /usr/local/lib/python${PYTHON_VERSION}/site-packages
 
 RUN if [ "${IPYKERNEL}" = "ipykernel" ]; then \
-    pip install -r /source/stempy/docker/requirements-ipykernel.txt; \
+    pip install --no-cache-dir -r /source/stempy/docker/requirements-ipykernel.txt; \
     elif [ "${MPI}" = "ON" ]; then \
-    pip install -r /source/stempy/docker/requirements-mpi.txt; \
+    pip install --no-cache-dir -r /source/stempy/docker/requirements-mpi.txt; \
     else \
-    pip install -r /source/stempy/docker/requirements-normal.txt; \
+    pip install --no-cache-dir -r /source/stempy/docker/requirements-normal.txt; \
     fi                                                                                        && \
     rm -rf /source/stempy
 


### PR DESCRIPTION
`mpi4py` defaults to using setuptools as backend. Changing this to `scikit-build-core` was the key here. 

Other things are useful anyway, so I keep them here - upgrading action version, and not using cache directory (smaller image sizes).