### PR TITLE
[#334] use safe_array for np v1 or v2

### DIFF
--- a/examples/sum_scans.ipynb
+++ b/examples/sum_scans.ipynb
@@ -26,7 +26,8 @@
     "import ncempy.io as nio\n",
     "\n",
     "import stempy.io as stio\n",
-    "import stempy.image as stim\n"
+    "import stempy.image as stim\n",
+    "from stempy.utils import safe_array\n"
    ]
   },
   {
@@ -83,7 +84,7 @@
     "for ii in range(all[0].shape[0]):\n",
     "    tt = np.hstack([pp[ii] for pp in all])\n",
     "    out.append(tt)\n",
-    "events_summed = np.array([np.array(x, copy=False) for x in out], dtype=np.object)"
+    "events_summed = np.array([safe_array(x, copy=False) for x in out], dtype=np.object)"
    ]
   },
   {

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -6,6 +6,7 @@ from stempy.io import (
     get_hdf5_reader, ReaderMixin, PyReader, SectorThreadedReader,
     SectorThreadedMultiPassReader, SparseArray
 )
+from stempy.utils import safe_array
 
 import h5py
 import numpy as np
@@ -118,8 +119,8 @@ def create_stem_images(input, inner_radii, outer_radii, scan_dimensions=(0, 0),
         raise Exception('Type of input, ' + str(type(input)) +
                         ', is not known to stempy.image.create_stem_images()')
 
-    images = [np.array(img, copy=False) for img in imgs]
-    return np.array(images, copy=False)
+    images = [safe_array(img, copy=False) for img in imgs]
+    return safe_array(images, copy=False)
 
 def create_stem_histogram(numBins, reader, inner_radii,
                           outer_radii, scan_dimensions=(0, 0),
@@ -158,8 +159,8 @@ def create_stem_histogram(numBins, reader, inner_radii,
     for inImage in imgs:
         bins = _image.get_container(inImage, numBins)
         freq = _image.create_stem_histogram(inImage, numBins, bins)
-        bins = np.array(bins, copy=False)
-        freq = np.array(freq, copy=False)
+        bins = safe_array(bins, copy=False)
+        freq = safe_array(freq, copy=False)
         allBins.append(bins)
         allFreqs.append(freq)
 
@@ -186,7 +187,7 @@ def calculate_average(reader):
     :rtype: stempy.image.ImageArray
     """
     image =  _image.calculate_average(reader.begin(), reader.end())
-    img = ImageArray(np.array(image, copy = False))
+    img = ImageArray(safe_array(image, copy=False))
     img._image = image
 
     return img
@@ -332,7 +333,7 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
     np_data = np.empty((num_scans, frames_per_scan), dtype=object)
     for i, scan_frames in enumerate(data.data):
         for j, sparse_frame in enumerate(scan_frames):
-            np_data[i, j] = np.array(sparse_frame, copy=False)
+            np_data[i, j] = safe_array(sparse_frame, copy=False)
 
     metadata = _electron_counted_metadata_to_dict(data.metadata)
 
@@ -371,7 +372,7 @@ def radial_sum(reader, center=(-1, -1), scan_dimensions=(0, 0)):
     sum =  _image.radial_sum(reader.begin(), reader.end(), scan_dimensions,
                              center)
 
-    return np.array(sum, copy=False)
+    return safe_array(sum, copy=False)
 
 
 def maximum_diffraction_pattern(reader, darkreference=None):
@@ -391,7 +392,7 @@ def maximum_diffraction_pattern(reader, darkreference=None):
         image = _image.maximum_diffraction_pattern(reader.begin(), reader.end(), darkreference)
     else:
         image = _image.maximum_diffraction_pattern(reader.begin(), reader.end())
-    img = ImageArray(np.array(image, copy=False))
+    img = ImageArray(safe_array(image, copy=False))
     img._image = image
 
     return img

--- a/python/stempy/io/__init__.py
+++ b/python/stempy/io/__init__.py
@@ -6,6 +6,7 @@ from stempy._io import (
     _reader, _sector_reader, _pyreader, _threaded_reader,
     _threaded_multi_pass_reader
 )
+from stempy.utils import safe_array
 
 # For exporting SparseArray
 from .sparse_array import SparseArray
@@ -46,7 +47,7 @@ class ReaderMixin(object):
         block = namedtuple('Block', ['header', 'data'])
         block._block = b
         block.header = b.header
-        block.data = np.array(b, copy = False)
+        block.data = safe_array(b, copy=False)
 
         return block
 
@@ -142,7 +143,7 @@ class SectorThreadedMultiPassReader(ReaderMixin, _threaded_multi_pass_reader):
             block = namedtuple('Block', ['header', 'data'])
             block._block = b
             block.header = b.header
-            block.data = np.array(b, copy=False)[0]
+            block.data = safe_array(b, copy=False)[0]
             blocks.append(block)
 
         return blocks[0] if single_index_frame else blocks

--- a/python/stempy/utils.py
+++ b/python/stempy/utils.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 try:
     # Use importlib metadata if available (python >=3.8)
     from importlib.metadata import version, PackageNotFoundError
@@ -18,3 +20,30 @@ def get_version():
     except PackageNotFoundError:
         # package is not installed
         pass
+
+
+def is_numpy_v2():
+    # https://github.com/scipy/scipy/pull/20172/files#diff-d28fbb0be287769c763ce61b0695feb0a6ca0e67b28bafee20526b46be7aaa84R61
+    if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+        return True
+    else:
+        return False
+
+
+def safe_array(data, copy=False):
+    """Create numpy array with safe handling for numpy 2.0+ copy behavior.
+
+    In numpy 2.0+, np.array(..., copy=False) raises an error if a copy is needed.
+    This function uses np.asarray() for numpy 2.0+ and np.array(..., copy=False)
+    for older versions.
+
+    :param data: input data to convert to array
+    :param copy: for numpy < 2.0, whether to avoid copying data
+    :return: numpy array
+    """
+    if is_numpy_v2():
+        # For numpy 2.0+, use asarray which allows copies when needed
+        return np.asarray(data)
+    else:
+        # For numpy < 2.0, use the old behavior
+        return np.array(data, copy=copy)


### PR DESCRIPTION
this fixes the upgrade from np 1 -> 2 for certain functions that use `np.array(data, copy=False)`