### PR TITLE
Set threshold directly in electron_count

### DIFF
--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -194,6 +194,7 @@ def calculate_average(reader):
 
 
 def electron_count(reader, darkreference=None, number_of_samples=40,
+                   background_threshold=None, xray_threshold=None,
                    background_threshold_n_sigma=4, xray_threshold_n_sigma=10,
                    threshold_num_blocks=1, scan_dimensions=(0, 0),
                    verbose=False, gain=None, apply_row_dark=False,
@@ -209,6 +210,14 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
     :param number_of_samples: the number of samples to take when calculating
                               the thresholds.
     :type number_of_samples: int
+    :param background_threshold: The value used as the background threshold.
+                                 If this is not set then the n_sigma is used
+                                 and the value is estimated from the data.
+    :type background_threshold: int
+    :param xray_threshold: The value used as the x-ray threshold.
+                                 If this is not set then the n_sigma is used
+                                 and the value is estimated from the data.
+    :type xray_threshold: int
     :param background_threshold_n_sigma: N-Sigma used for calculating the
                                          background threshold.
     :type background_threshold_n_sigma: int
@@ -287,10 +296,15 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
         if gain is not None:
             args.append(gain)
 
-        res = _image.calculate_thresholds(*args)
-
-        background_threshold = res.background_threshold
-        xray_threshold = res.xray_threshold
+        # Determine the threshold. This is either directly set by the user
+        # or calculated from the data with a Gaussian fit to the noise and
+        # the threshold is a set number of sigma of that Gaussian.
+        if background_threshold is None or xray_threshold is None:
+            res = _image.calculate_thresholds(*args)
+            if background_threshold is None:
+                background_threshold = res.background_threshold
+            if xray_threshold is None:
+                xray_threshold = res.xray_threshold
 
         if verbose:
             print('****Statistics for calculating electron thresholds****')

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -201,9 +201,9 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
 
     :param reader: the file reader that has already opened the data.
     :type reader: stempy.io.reader
-    :param darkreference: the dark reference to subtract, potentially generated
-                          via stempy.image.calculate_average().
-    :type darkreference: stempy.image.ImageArray or stempy::Image<double>
+    :param darkreference: the dark reference to subtract. For an empty dark
+                              use np.zeros((Nx, Ny)).
+    :type darkreference: numpy.ndimage
     :param number_of_samples: the number of samples to take when calculating
                               the thresholds.
     :type number_of_samples: int

--- a/python/stempy/image/__init__.py
+++ b/python/stempy/image/__init__.py
@@ -201,9 +201,9 @@ def electron_count(reader, darkreference=None, number_of_samples=40,
 
     :param reader: the file reader that has already opened the data.
     :type reader: stempy.io.reader
-    :param darkreference: the dark reference to subtract. For an empty dark
-                              use np.zeros((Nx, Ny)).
-    :type darkreference: numpy.ndimage
+    :param darkreference: the dark reference to subtract, potentially generated
+                          via stempy.image.calculate_average().
+    :type darkreference: stempy.image.ImageArray or stempy::Image<double>
     :param number_of_samples: the number of samples to take when calculating
                               the thresholds.
     :type number_of_samples: int


### PR DESCRIPTION
I think it might be more convenient to set the threshold directly when electron counting sometimes. Here I add two new keywords and some logic to test for those keywords. 

I have not tested this yet, but the code looks ok to me.

@cjh1 @swelborn What do you think of this method for checking the keywords? Also, do we have a test for electron_counting? We would need a raw data set available to the tests which is a large amount of data. 

Ill test this once I can get the docker container built with this code.