### PR TITLE
Update wheel building workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,8 +9,8 @@ on:
   pull_request:
 
 env:
-  # Only support 64-bit CPython > 3.6
-  CIBW_SKIP: "cp36-* pp* *-manylinux_i686 *-musllinux_* *-win32 cp313-*"
+  # Only support 64-bit CPython >= 3.10
+  CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* pp* *-manylinux_i686 *-musllinux_* *-win32"
 
   # This has some of the software we need pre-installed on it
   CIBW_MANYLINUX_X86_64_IMAGE: openchemistry/stempy_wheel_builder_x86_64
@@ -23,12 +23,10 @@ env:
   CIBW_ENVIRONMENT_WINDOWS: >
     EXTRA_CMAKE_ARGS="-DEIGEN3_DIR=C:\\PROGRA~2\\Eigen3\\share\\eigen3\\cmake\\;-Dstempy_ENABLE_HDF5=OFF"
     USE_PYTHON_IN_PATH=1
-
   # Get cmake to use python in the path...
   CIBW_ENVIRONMENT_MACOS: >
     EXTRA_CMAKE_ARGS="-DHDF5_DIR=/usr/local/HDF_Group/HDF5/current/cmake"
     USE_PYTHON_IN_PATH=1
-
   CIBW_BEFORE_TEST: pip install -r {project}/tests/requirements.txt
 
   CIBW_TEST_COMMAND: pytest {project}/tests
@@ -64,7 +62,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: . .github/scripts/install.sh

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -10,7 +10,8 @@ on:
 
 env:
   # Only support 64-bit CPython >= 3.10
-  CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* pp* *-manylinux_i686 *-musllinux_* *-win32"
+  CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+  CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *-win32"
 
   # This has some of the software we need pre-installed on it
   CIBW_MANYLINUX_X86_64_IMAGE: openchemistry/stempy_wheel_builder_x86_64


### PR DESCRIPTION
We are using python 3.10 to build and getting warnings like this:
"cibuildwheel 3 will require Python 3.11+, please upgrade the Python version used to run cibuildwheel. This does not affect the versions you can target when building wheels."
This uses python 3.12 to build.

Also, update build workflow to support CPython >= 3.10 by skipping older EOL versions of python. This should speed up the build process and reduce wasted resources.